### PR TITLE
Selector no type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # HEAD
 
 - Removed: We don't need `scss/at-extend-no-missing-placeholder` anymore taken care of by `at-rule-blacklist`
+- Added: Adding `selector-no-type` to the rules
 
 # 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ This is a list of the lints turned on in this configuration, and what they do.
 * [selector-max-specificity](http://stylelint.io/user-guide/rules/selector-max-specificity/): Limit the specificity of selectors to `"0,4,0"`.
 * [selector-no-id](http://stylelint.io/user-guide/rules/selector-no-id/): Disallow id selectors.
 * [selector-no-qualifying-type](http://stylelint.io/user-guide/rules/selector-no-qualifying-type/): Disallow qualifying a selector by type.
+* [selector-no-type](http://stylelint.io/user-guide/rules/selector-no-type/): Disallow type selectors.
 * [selector-pseudo-class-case](http://stylelint.io/user-guide/rules/selector-pseudo-class-case/): pseudo-class selectors should always be lowercase.
 * [selector-pseudo-class-parentheses-space-inside](http://stylelint.io/user-guide/rules/selector-pseudo-class-parentheses-space-inside/): There must never be whitespace on the inside the parentheses.
 * [selector-pseudo-element-case](http://stylelint.io/user-guide/rules/selector-pseudo-element-case/): pseudo-element selectors should always be lowercase.

--- a/index.js
+++ b/index.js
@@ -310,6 +310,7 @@ module.exports = {
     "selector-max-specificity": "0,4,0",
     "selector-no-id": true,
     "selector-no-qualifying-type": true,
+    "selector-no-type": true,
     "selector-pseudo-class-case": "lower",
     "selector-pseudo-class-parentheses-space-inside": "never",
     "selector-pseudo-element-case": "lower",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/primer/stylelint-config-primer#readme",
   "dependencies": {
-    "stylelint-scss": "^1.2.1",
+    "stylelint-scss": "^1.3.4",
     "stylelint-selector-no-utility": "^1.2.0"
   },
   "devDependencies": {

--- a/tests/index.js
+++ b/tests/index.js
@@ -9,7 +9,7 @@ const validCss =
 `
 
 const invalidCss =
-`a {
+`.foo {
   top: .2em;
 }
 `


### PR DESCRIPTION
This adds the rule [selector-no-type](http://stylelint.io/user-guide/rules/selector-no-type/) to the config. 

I thought it was in there before, but somehow it got dropped off.