### PR TITLE
Prevent units in zero values

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ This is a list of the lints turned on in this configuration, and what they do.
 * [number-leading-zero](http://stylelint.io/user-guide/rules/number-leading-zero/): There must always be a leading zero.
 * [number-no-trailing-zeros](http://stylelint.io/user-guide/rules/number-no-trailing-zeros/): Disallow trailing zeros in numbers.
 
+#### Length
+
+* [length-zero-no-unit](http://stylelint.io/user-guide/rules/length-zero-no-unit/): Disallow units for zero lengths.
+
 #### Property
 
 * [property-case](http://stylelint.io/user-guide/rules/property-case/): Properties must be written in lowercase.

--- a/index.js
+++ b/index.js
@@ -248,6 +248,7 @@ module.exports = {
     "function-url-quotes": "always",
     "function-whitespace-after": "always",
     "indentation": 2,
+    "length-zero-no-unit": true,
     "max-empty-lines": 1,
     "max-nesting-depth": 3,
     "media-feature-colon-space-after": "always",


### PR DESCRIPTION
For code cleanliness, we should not allow units to be specified on `0` values. Reference: http://stylelint.io/user-guide/rules/length-zero-no-unit/

/cc @jonrohan @broccolini 