### PR TITLE
Remove selector-class-pattern rule from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+- Removed: `selector-class-pattern` from config. https://github.com/primer/stylelint-config-primer/pull/11
+
 # 1.3.0
 
 - Added: `length-zero-no-unit` to disallow zero values with units eg `0px`

--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ This is a list of the lints turned on in this configuration, and what they do.
 * [selector-attribute-brackets-space-inside](http://stylelint.io/user-guide/rules/selector-attribute-brackets-space-inside/): There must never be whitespace on the inside the brackets.
 * [selector-attribute-operator-space-after](http://stylelint.io/user-guide/rules/selector-attribute-operator-space-after/): There must never be a single after after the operator.
 * [selector-attribute-operator-space-before](http://stylelint.io/user-guide/rules/selector-attribute-operator-space-before/): There must never be a single before after the operator.
-* [selector-class-pattern](http://stylelint.io/user-guide/rules/selector-class-pattern/): Selectors must match the regex `^(?!(js\\-))[a-z\\-0-9]+$`.
 * [selector-combinator-space-after](http://stylelint.io/user-guide/rules/selector-combinator-space-after/): There must always be a single space after the combinators.
 * [selector-combinator-space-before](http://stylelint.io/user-guide/rules/selector-combinator-space-before/): There must always be a single space before the combinators.
 * [selector-max-compound-selectors](http://stylelint.io/user-guide/rules/selector-max-compound-selectors/): Limit the number of compound selectors in a selector to `3`.

--- a/index.js
+++ b/index.js
@@ -296,12 +296,6 @@ module.exports = {
     "selector-attribute-brackets-space-inside": "never",
     "selector-attribute-operator-space-after": "never",
     "selector-attribute-operator-space-before": "never",
-    "selector-class-pattern": [
-      "^(?!(js\\-))[a-z\\-0-9]+$",
-      {
-        "message": "Selector should be written in lowercase with hyphens (selector-class-pattern)"
-      }
-    ],
     "selector-combinator-space-after": "always",
     "selector-combinator-space-before": "always",
     "selector-list-comma-newline-after": "always",

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
     "stylelint-selector-no-utility": "^1.3.0"
   },
   "devDependencies": {
-    "ava": "^0.17.0",
-    "eslint": "^3.0.1",
-    "eslint-plugin-github": "^0.7.0",
-    "stylelint": "^7.4.2"
+    "ava": "*",
+    "eslint": "*",
+    "eslint-plugin-github": "*",
+    "stylelint": "*"
   },
   "peerDependencies": {
     "stylelint": "^7.4.2"


### PR DESCRIPTION
We have a `selector-class-pattern` rule turned on, but we're in a transition period where the old naming and the new naming don't match. This has led to a lot of disabling in files, so until we're at a point where the new pattern is more prevalent, I'm turning this off.

cc @broccolini  