### PR TITLE
replace declaration-block-properties-order rules (deprecated) by stylelint-order plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 module.exports = {
   "plugins": [
     "stylelint-scss",
-    "stylelint-selector-no-utility"
+    "stylelint-selector-no-utility",
+    "stylelint-order"
   ],
   "rules": {
     "at-rule-blacklist": ["extend"],
@@ -42,7 +43,7 @@ module.exports = {
       }
     ],
     "declaration-block-no-shorthand-property-overrides": true,
-    "declaration-block-properties-order": [
+    "order/properties-order": [
       "position",
       "top",
       "right",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "ava": "*",
     "eslint": "*",
     "eslint-plugin-github": "*",
-    "stylelint": "*"
+    "stylelint": "*",
+    "stylelint-order": "^0.4.4"
   },
   "peerDependencies": {
     "stylelint": "^7.7.1"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ava": "*",
     "eslint": "*",
     "eslint-plugin-github": "*",
+    "eslint-plugin-import": "^2.6.0",
     "stylelint": "*",
     "stylelint-order": "^0.4.4"
   },

--- a/tests/index.js
+++ b/tests/index.js
@@ -10,6 +10,7 @@ const validCss =
 
 const invalidCss =
 `.foo {
+  color: #fff;
   top: .2em;
 }
 `
@@ -47,7 +48,8 @@ test("a warning with invalid css", t => {
     const { errored, results } = data
     const { warnings } = results[0]
     t.truthy(errored, "errored")
-    t.is(warnings.length, 1, "flags one warning")
-    t.is(warnings[0].text, "Expected a leading zero (number-leading-zero)", "correct warning text")
+    t.is(warnings.length, 2, "flags two warning")
+    t.is(warnings[0].text, 'Expected "top" to come before "color" (order/properties-order)', "correct warning text")
+    t.is(warnings[1].text, "Expected a leading zero (number-leading-zero)", "correct warning text")
   })
 })


### PR DESCRIPTION
Because stylelint 7.10.1 warning:
Deprecation Warning: 'declaration-block-properties-order'has been deprecated and in 8.0 will be removed. Instead use the community 'stylelint-order' plugin pack. See: https://stylelint.io/user-guide/rules/declaration-block-properties-order/

so I replace declaration-block-properties-order rules (deprecated) by stylelint-order plugin