### PR TITLE
Update changelog for v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # HEAD
 
+# 2.0.0
+
+:boom: **The following updates are breaking changes**, since code that disables the deprecated rule will now produce linting errors. Please update your `stylelint-disable` statements accordingly.
+
+- Replaced `selector-no-id: true` with `selector-max-id: 0`
+- Replaced `selector-no-type: true` with `selector-max-type: 0`
+
+The rest of the changes should not introduce new linting errors:
+
+- Updated: moved [browserslist](https://github.com/ai/browserslist) spec to `package.json`
+- Updated: using the [`no-unsupported-browser-features` plugin](https://github.com/ismay/stylelint-no-unsupported-browser-features) instead of the deprecated `no-unsupported-browser-features` rule
+- Removed: `media-feature-no-missing-punctuation`
+- Updated: replaced `rule-nested-empty-line-before` and `rule-non-nested-empty-line-before` with `rule-empty-line-before`
+
 # 1.4.0
 
 - Updated: Development dependencies are any version `*`


### PR DESCRIPTION
I forgot to update the changelog when publishing v2.0.0. If we need this to be included in the distribution, we can publish a patch release. Otherwise, I think it's fine to just merge.

### [:eyes: Check it out here](https://github.com/primer/stylelint-config-primer/blob/changelog-2.0.0/CHANGELOG.md#200)