### PR TITLE
Release 6.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-primer",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -265,9 +265,9 @@
       }
     },
     "@primer/css": {
-      "version": "12.0.0-rc.5e301d3",
-      "resolved": "https://registry.npmjs.org/@primer/css/-/css-12.0.0-rc.5e301d3.tgz",
-      "integrity": "sha512-ZnnMWaFYbiF+RwF5Wif7gytl8ZL8ve+57tRbcogh+/53sLmhmG9GKnz6RmT2f5ZLwEoIFwH64IRiZV93cnDzbA==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@primer/css/-/css-12.2.0.tgz",
+      "integrity": "sha512-RDavaudOWWta5X11p/q7+nSS+5p+FHCbKWXkHECm1THQ+l1bRk5FUr9Csy78lbqbknqnlF1Lw9qePAG+S4+WgQ==",
       "dev": true
     },
     "JSONStream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7162,7 +7162,8 @@
         },
         "fill-range": {
           "version": "2.2.3",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+          "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
           "requires": {
             "is-number": "^2.1.0",
             "isobject": "^2.0.0",
@@ -8657,9 +8658,9 @@
       }
     },
     "stylelint-selector-no-utility": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/stylelint-selector-no-utility/-/stylelint-selector-no-utility-3.0.1.tgz",
-      "integrity": "sha512-r0g+H5ROlI5oHmZnaZK5QdWImsofQfcWFUwK53emgJvB+nZle9g6DUer8VeH4UYia59rM8qx94q1vbt2/RM5XQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-selector-no-utility/-/stylelint-selector-no-utility-4.0.0.tgz",
+      "integrity": "sha512-C3o1nTwTiRldiLwnN7H99GUJU3xjHGFY1SKc5d87Gljxr1I5EfD7V0/I6UNU/hxd5wWJg5o0XiqFEor+Rbwf1Q==",
       "requires": {
         "stylelint": "^7.13.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-primer",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Sharable stylelint config used by GitHub's CSS",
   "homepage": "http://primer.style/css/tools",
   "author": "GitHub, Inc.",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "stylelint-selector-no-utility": "3.0.1"
   },
   "devDependencies": {
-    "@primer/css": "^12.0.0-rc.5e301d3",
+    "@primer/css": "^12.2.0",
     "eslint": "4.19.1",
     "eslint-plugin-github": "^1.8.1",
     "eslint-plugin-import": "^2.16.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "stylelint-no-unsupported-browser-features": "^1.0.0",
     "stylelint-order": "^2.0.0",
     "stylelint-scss": "3.5.2",
-    "stylelint-selector-no-utility": "3.0.1"
+    "stylelint-selector-no-utility": "4.0.0"
   },
   "devDependencies": {
     "@primer/css": "^12.2.0",


### PR DESCRIPTION
This updates to [stylelint-selector-no-utility v4.0.0](https://github.com/primer/stylelint-selector-no-utility/releases/tag/v4.0.0), which is a breaking change because it requires `@primer/css` as a peer dependency.

We don't have to declare it as a peer dependency here because it's a dev dependency already. I've updated our version to `^12.2.0` just so that we're testing with a recent version.