### PR TITLE
Import selector-no-utility, make it configurable

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+coverage/
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-node_modules
-npm-debug.log
+*.log
+coverage/
+node_modules/

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -5,7 +5,6 @@ const SAFE_SCSS_EXAMPLE = `
 `
 
 describe('stylelint-config-primer', () => {
-
   it('stylelint runs with our config', () => {
     return lint('.bold { font-weight: bold; }').then(data => {
       expect(data).not.toHaveErrored()
@@ -50,11 +49,14 @@ describe('stylelint-config-primer', () => {
   })
 
   it('warns about the planned deprecation of primer/selector-no-utility', () => {
-    return lint(SAFE_SCSS_EXAMPLE, extendDefaultConfig({
-      rules: {
-        'primer/selector-no-utility': true
-      }
-    })).then(data => {
+    return lint(
+      SAFE_SCSS_EXAMPLE,
+      extendDefaultConfig({
+        rules: {
+          'primer/selector-no-utility': true
+        }
+      })
+    ).then(data => {
       expect(data).not.toHaveErrored()
       expect(data).not.toHaveResultsLength(0)
       expect(data).toHaveDeprecationsLength(1)
@@ -66,5 +68,4 @@ describe('stylelint-config-primer', () => {
       ])
     })
   })
-
 })

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -88,7 +88,7 @@ describe('stylelint-config-primer', () => {
         expect(errored).toBe(true)
         expect(warnings).toHaveLength(1)
         expect(warnings[0].text.trim()).toBe(
-          'Avoid styling the utility class selector ".text-gray" (primer/no-override)'
+          `The class selector ".text-gray" is immutable. (primer/no-override)`
         )
       })
   })

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -87,9 +87,7 @@ describe('stylelint-config-primer', () => {
         const {warnings} = results[0]
         expect(errored).toBe(true)
         expect(warnings).toHaveLength(1)
-        expect(warnings[0].text.trim()).toBe(
-          `The class selector ".text-gray" is immutable. (primer/no-override)`
-        )
+        expect(warnings[0].text.trim()).toBe(`The class selector ".text-gray" is immutable. (primer/no-override)`)
       })
   })
 })

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,41 +1,35 @@
 const config = require('../')
 const stylelint = require('stylelint')
 
-const validCss = `
-.selector-x { width: 10%; }
-.selector-y { width: 20%; }
-.selector-z { width: 30%; }
-`
-
-const invalidCss = `
-.foo {
-  color: #fff;
-  top: .2em;
-}
-`
-
 describe('stylelint-config-primer', () => {
   it('stylelint runs with our config', () => {
     return stylelint
       .lint({
-        code: 'a { font-weight: bold; }',
+        code: '.bold { font-weight: bold; }\n',
         config
       })
       .then(data => {
         expect(data).toBeInstanceOf(Object)
+        const {errored, results} = data
+        expect(errored).toBe(false)
+        expect(results).toHaveLength(1)
       })
   })
 
   it('produces zero warnings with valid css', () => {
     return stylelint
       .lint({
-        code: validCss,
+        code: `
+.selector-x { width: 10%; }
+.selector-y { width: 20%; }
+.selector-z { width: 30%; }
+`,
         config
       })
       .then(data => {
         const {errored, results} = data
         const {warnings} = results[0]
-        expect(errored).toBeFalsy()
+        expect(errored).toBe(false)
         expect(warnings).toHaveLength(0)
       })
   })
@@ -43,13 +37,18 @@ describe('stylelint-config-primer', () => {
   it('generates one warning with invalid css', () => {
     return stylelint
       .lint({
-        code: invalidCss,
+        code: `
+.foo {
+  color: #fff;
+  top: .2em;
+}
+`,
         config
       })
       .then(data => {
         const {errored, results} = data
         const {warnings} = results[0]
-        expect(errored).toBeTruthy()
+        expect(errored).toBe(true)
         expect(warnings).toHaveLength(2)
         expect(warnings[0].text.trim()).toBe('Expected "top" to come before "color" (order/properties-order)')
         expect(warnings[1].text.trim()).toBe('Expected a leading zero (number-leading-zero)')
@@ -65,13 +64,31 @@ describe('stylelint-config-primer', () => {
       })
       .then(data => {
         const {errored, results} = data
-        expect(errored).toBeFalsy()
+        expect(errored).toBe(false)
         expect(results).not.toHaveLength(0)
         expect(results[0].deprecations).toHaveLength(
           0,
           `Expected there to be no deprecated config warnings. Please fix these:\n\n${results[0].deprecations
             .map(d => d.text)
             .join('\n')}`
+        )
+      })
+  })
+
+  it('reports instances of utility classes', () => {
+    return stylelint
+      .lint({
+        code: '.text-gray { color: #111; }\n',
+        config,
+        syntax: 'scss'
+      })
+      .then(data => {
+        const {errored, results} = data
+        const {warnings} = results[0]
+        expect(errored).toBe(true)
+        expect(warnings).toHaveLength(1)
+        expect(warnings[0].text.trim()).toBe(
+          'Avoid styling the utility class selector ".text-gray" (primer/no-override)'
         )
       })
   })

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,93 +1,107 @@
-const config = require('../')
+const {join} = require('path')
+const dedent = require('dedent')
 const stylelint = require('stylelint')
+const defaultConfig = require('../')
+
+const lint = (code, config = defaultConfig, options = {}) => {
+  return stylelint.lint(
+    Object.assign(options, {
+      code: dedent(code) + '\n',
+      config
+    })
+  )
+}
 
 describe('stylelint-config-primer', () => {
   it('stylelint runs with our config', () => {
-    return stylelint
-      .lint({
-        code: '.bold { font-weight: bold; }\n',
-        config
-      })
-      .then(data => {
-        expect(data).toBeInstanceOf(Object)
-        const {errored, results} = data
-        expect(errored).toBe(false)
-        expect(results).toHaveLength(1)
-      })
+    return lint('.bold { font-weight: bold; }').then(data => {
+      expect(data).toBeInstanceOf(Object)
+      const {errored, results} = data
+      expect(errored).toBe(false)
+      expect(results).toHaveLength(1)
+    })
   })
 
   it('produces zero warnings with valid css', () => {
-    return stylelint
-      .lint({
-        code: `
-.selector-x { width: 10%; }
-.selector-y { width: 20%; }
-.selector-z { width: 30%; }
-`,
-        config
-      })
-      .then(data => {
-        const {errored, results} = data
-        const {warnings} = results[0]
-        expect(errored).toBe(false)
-        expect(warnings).toHaveLength(0)
-      })
+    return lint(`
+        .selector-x { width: 10%; }
+        .selector-y { width: 20%; }
+        .selector-z { width: 30%; }
+      `).then(data => {
+      const {errored, results} = data
+      const {warnings} = results[0]
+      expect(warnings).toHaveLength(0)
+      expect(errored).toBe(false)
+    })
   })
 
   it('generates one warning with invalid css', () => {
-    return stylelint
-      .lint({
-        code: `
-.foo {
-  color: #fff;
-  top: .2em;
-}
-`,
-        config
-      })
-      .then(data => {
-        const {errored, results} = data
-        const {warnings} = results[0]
-        expect(errored).toBe(true)
-        expect(warnings).toHaveLength(2)
-        expect(warnings[0].text.trim()).toBe('Expected "top" to come before "color" (order/properties-order)')
-        expect(warnings[1].text.trim()).toBe('Expected a leading zero (number-leading-zero)')
-      })
+    return lint(`
+        .foo {
+          color: #fff;
+          top: .2em;
+        }
+      `).then(data => {
+      const {errored, results} = data
+      const {warnings} = results[0]
+      expect(errored).toBe(true)
+      expect(warnings).toHaveLength(2)
+      expect(warnings[0].text.trim()).toBe('Expected "top" to come before "color" (order/properties-order)')
+      expect(warnings[1].text.trim()).toBe('Expected a leading zero (number-leading-zero)')
+    })
   })
 
   it('does not report any deprecations', () => {
-    return stylelint
-      .lint({
-        code: '',
-        config,
-        syntax: 'scss'
-      })
-      .then(data => {
-        const {errored, results} = data
-        expect(errored).toBe(false)
-        expect(results).not.toHaveLength(0)
-        expect(results[0].deprecations).toHaveLength(
-          0,
-          `Expected there to be no deprecated config warnings. Please fix these:\n\n${results[0].deprecations
-            .map(d => d.text)
-            .join('\n')}`
-        )
-      })
+    return lint('').then(data => {
+      const {errored, results} = data
+      expect(errored).toBe(false)
+      expect(results).not.toHaveLength(0)
+      expect(results[0].deprecations).toHaveLength(
+        0,
+        `Expected there to be no deprecated config warnings. Please fix these:\n\n${results[0].deprecations
+          .map(d => d.text)
+          .join('\n')}`
+      )
+    })
+  })
+
+  it('warns about the planned deprecation of primer/selector-no-utility', () => {
+    return lint('', {
+      extends: join(__dirname, '..'),
+      rules: {
+        'primer/selector-no-utility': true
+      }
+    }).then(data => {
+      const {errored, results} = data
+      expect(errored).toBe(false)
+      expect(results).not.toHaveLength(0)
+      expect(results[0].deprecations).toEqual([
+        {
+          text: `'primer/selector-no-utility' has been deprecated and will be removed in stylelint-config-primer@7.0.0. Please update your rules to use 'primer/no-override'.`,
+          reference: 'https://github.com/primer/stylelint-config-primer#deprecations'
+        }
+      ])
+    })
   })
 
   it('reports instances of utility classes', () => {
-    return stylelint
-      .lint({
-        code: '.text-gray { color: #111; }\n',
-        config,
-        syntax: 'scss'
-      })
-      .then(data => {
-        const {errored, results} = data
-        const {warnings} = results[0]
-        expect(errored).toBe(true)
-        expect(warnings).toHaveLength(1)
-        expect(warnings[0].text.trim()).toBe(`The class selector ".text-gray" is immutable. (primer/no-override)`)
-      })
+    return lint('.text-gray { color: #111; }').then(data => {
+      const {errored, results} = data
+      const {warnings} = results[0]
+      expect(errored).toBe(true)
+      expect(warnings).toHaveLength(1)
+      expect(warnings[0].text.trim()).toBe(`The selector ".text-gray" should not be overridden. (primer/no-override)`)
+    })
+  })
+
+  it('reports instances of complete utility selectors', () => {
+    const selector = '.show-on-focus:focus'
+    return lint(`${selector} { color: #f00; }`).then(data => {
+      const {errored, results} = data
+      const {warnings} = results[0]
+      expect(errored).toBe(true)
+      expect(warnings).toHaveLength(1)
+      expect(warnings[0].text.trim()).toBe(`The selector "${selector}" should not be overridden. (primer/no-override)`)
+    })
   })
 })

--- a/__tests__/no-override.js
+++ b/__tests__/no-override.js
@@ -1,4 +1,4 @@
-const {lint, extendDefaultConfig} = require('./utils')
+const {lint} = require('./utils')
 
 describe('primer/no-override', () => {
   it('reports instances of utility classes', () => {
@@ -18,4 +18,3 @@ describe('primer/no-override', () => {
     })
   })
 })
-

--- a/__tests__/no-override.js
+++ b/__tests__/no-override.js
@@ -1,0 +1,21 @@
+const {lint, extendDefaultConfig} = require('./utils')
+
+describe('primer/no-override', () => {
+  it('reports instances of utility classes', () => {
+    return lint('.text-gray { color: #111; }').then(data => {
+      expect(data).toHaveErrored()
+      expect(data).toHaveWarningsLength(1)
+      expect(data).toHaveWarnings([`The selector ".text-gray" should not be overridden. (primer/no-override)`])
+    })
+  })
+
+  it('reports instances of complete utility selectors', () => {
+    const selector = '.show-on-focus:focus'
+    return lint(`${selector} { color: #f00; }`).then(data => {
+      expect(data).toHaveErrored()
+      expect(data).toHaveWarningsLength(1)
+      expect(data).toHaveWarnings([`The selector "${selector}" should not be overridden. (primer/no-override)`])
+    })
+  })
+})
+

--- a/__tests__/no-override.js
+++ b/__tests__/no-override.js
@@ -36,6 +36,9 @@ describe('primer/no-override', () => {
     return lint('', config).then(data => {
       expect(data).not.toHaveErrored()
       expect(data.results[0].invalidOptionWarnings).toHaveLength(1)
+      expect(data.results[0].invalidOptionWarnings[0]).toEqual({
+        text: `The "bundles" option must be an array of valid bundles; got: "asdf"`
+      })
     })
   })
 })

--- a/__tests__/no-override.js
+++ b/__tests__/no-override.js
@@ -1,4 +1,4 @@
-const {lint} = require('./utils')
+const {lint, extendDefaultConfig} = require('./utils')
 
 describe('primer/no-override', () => {
   it('reports instances of utility classes', () => {
@@ -15,6 +15,27 @@ describe('primer/no-override', () => {
       expect(data).toHaveErrored()
       expect(data).toHaveWarningsLength(1)
       expect(data).toHaveWarnings([`The selector "${selector}" should not be overridden. (primer/no-override)`])
+    })
+  })
+
+  it('reports instances of partial utility selectors', () => {
+    const selector = '.show-on-focus'
+    return lint(`.foo ${selector}:focus { color: #f00; }`).then(data => {
+      expect(data).toHaveErrored()
+      expect(data).toHaveWarningsLength(1)
+      expect(data).toHaveWarnings([`The selector "${selector}" should not be overridden. (primer/no-override)`])
+    })
+  })
+
+  it('warns when you pass an invalid bundle name', () => {
+    const config = extendDefaultConfig({
+      rules: {
+        'primer/no-override': [true, {bundles: ['asdf']}]
+      }
+    })
+    return lint('', config).then(data => {
+      expect(data).not.toHaveErrored()
+      expect(data.results[0].invalidOptionWarnings).toHaveLength(1)
     })
   })
 })

--- a/__tests__/utils/index.js
+++ b/__tests__/utils/index.js
@@ -10,15 +10,18 @@ module.exports = {
 }
 
 function extendDefaultConfig(config) {
-  return Object.assign({
-    extends: join(__dirname, '../..')
-  }, config)
+  return Object.assign(
+    {
+      extends: join(__dirname, '../..')
+    },
+    config
+  )
 }
 
 function lint(code, config = defaultConfig, options = {}) {
   return stylelint.lint(
     Object.assign(options, {
-      code: dedent(code).trim() + '\n',
+      code: `${dedent(code).trim()}\n`,
       config
     })
   )

--- a/__tests__/utils/index.js
+++ b/__tests__/utils/index.js
@@ -1,0 +1,25 @@
+const dedent = require('dedent')
+const stylelint = require('stylelint')
+const {join} = require('path')
+const defaultConfig = require('../..')
+
+module.exports = {
+  lint,
+  defaultConfig,
+  extendDefaultConfig
+}
+
+function extendDefaultConfig(config) {
+  return Object.assign({
+    extends: join(__dirname, '../..')
+  }, config)
+}
+
+function lint(code, config = defaultConfig, options = {}) {
+  return stylelint.lint(
+    Object.assign(options, {
+      code: dedent(code).trim() + '\n',
+      config
+    })
+  )
+}

--- a/__tests__/utils/setup.js
+++ b/__tests__/utils/setup.js
@@ -1,0 +1,47 @@
+expect.extend({
+  toHaveErrored(data) {
+    return {
+      pass: data.errored,
+      message: () => `Expected "errored" === ${!data.errored}, but got ${data.errored}:
+- ${data.results[0].warnings.map(warning => warning.text).join('\n- ')}`
+    }
+  },
+
+  toHaveResultsLength(data, length) {
+    return {
+      pass: data.results.length === length,
+      message: () => `Expected results.length === ${length}, but got ${data.results.length}`
+    }
+  },
+
+  toHaveWarningsLength(data, length) {
+    const {warnings} = data.results[0]
+    return {
+      pass: warnings.length === length,
+      message: () => `Expected results[0].warnings.length === ${length}, but got ${warnings.length}:
+- ${warnings.map(warning => warning.text).join('\n- ')}`
+    }
+  },
+
+  toHaveWarnings(data, warningTexts) {
+    const set = warningTexts
+    const trimmedWarnings = new Set(data.results[0].warnings.map(({text}) => text.trim()))
+    return {
+      pass: warningTexts.every(text => trimmedWarnings.has(text)),
+      message: () => `Expected to find the following warnings:
+- ${warningTexts.filter(text => !trimmedWarnings.has(text)).join('\n- ')}
+
+But got instead:
+- ${data.results[0].warnings.map(warning => warning.text).join('\n- ')}
+`
+    }
+  },
+
+  toHaveDeprecationsLength(data, length) {
+    const {deprecations} = data.results[0]
+    return {
+      pass: deprecations.length === length,
+      message: () => `Expected ${length} deprecations, but got ${deprecations.length}`
+    }
+  }
+})

--- a/__tests__/utils/setup.js
+++ b/__tests__/utils/setup.js
@@ -24,7 +24,6 @@ expect.extend({
   },
 
   toHaveWarnings(data, warningTexts) {
-    const set = warningTexts
     const trimmedWarnings = new Set(data.results[0].warnings.map(({text}) => text.trim()))
     return {
       pass: warningTexts.every(text => trimmedWarnings.has(text)),

--- a/index.js
+++ b/index.js
@@ -2,7 +2,13 @@ const browsers = require('./browsers')
 const propertyOrder = require('./property-order')
 
 module.exports = {
-  plugins: ['stylelint-no-unsupported-browser-features', 'stylelint-order', 'stylelint-scss', './plugins/no-override'],
+  plugins: [
+    'stylelint-no-unsupported-browser-features',
+    'stylelint-order',
+    'stylelint-scss',
+    './plugins/no-override',
+    './plugins/selector-no-utility'
+  ],
   rules: {
     'at-rule-blacklist': ['extend'],
     'at-rule-name-case': 'lower',

--- a/index.js
+++ b/index.js
@@ -2,12 +2,7 @@ const browsers = require('./browsers')
 const propertyOrder = require('./property-order')
 
 module.exports = {
-  plugins: [
-    'stylelint-no-unsupported-browser-features',
-    'stylelint-order',
-    'stylelint-selector-no-utility',
-    'stylelint-scss'
-  ],
+  plugins: ['stylelint-no-unsupported-browser-features', 'stylelint-order', 'stylelint-scss', './plugins/no-override'],
   rules: {
     'at-rule-blacklist': ['extend'],
     'at-rule-name-case': 'lower',
@@ -92,7 +87,7 @@ module.exports = {
         browsers
       }
     ],
-    'primer/selector-no-utility': true,
+    'primer/no-override': true,
     'property-case': 'lower',
     'property-no-vendor-prefix': true,
     'rule-empty-line-before': [

--- a/index.js
+++ b/index.js
@@ -1,3 +1,10 @@
+// we do this here rather than in each of the plugins
+try {
+  require.resolve('@primer/css')
+} catch (error) {
+  throw new Error(`Unable to require('@primer/css')! Did you install it as a peerDependency?`)
+}
+
 const browsers = require('./browsers')
 const propertyOrder = require('./property-order')
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,14 +1,6 @@
 module.exports = {
   collectCoverage: true,
-  collectCoverageFrom: [
-    'src/*.js',
-    'plugins/*.js'
-  ],
-  setupFilesAfterEnv: [
-    '<rootDir>/__tests__/utils/setup.js'
-  ],
-  testPathIgnorePatterns: [
-    '/node_modules/',
-    '__tests__/utils'
-  ]
+  collectCoverageFrom: ['src/*.js', 'plugins/*.js'],
+  setupFilesAfterEnv: ['<rootDir>/__tests__/utils/setup.js'],
+  testPathIgnorePatterns: ['/node_modules/', '__tests__/utils']
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  collectCoverage: true,
+  collectCoverageFrom: [
+    'src/*.js',
+    'plugins/*.js'
+  ],
+  setupFilesAfterEnv: [
+    '<rootDir>/__tests__/utils/setup.js'
+  ],
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '__tests__/utils'
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8657,14 +8657,6 @@
         "postcss-value-parser": "^3.3.1"
       }
     },
-    "stylelint-selector-no-utility": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-selector-no-utility/-/stylelint-selector-no-utility-4.0.0.tgz",
-      "integrity": "sha512-C3o1nTwTiRldiLwnN7H99GUJU3xjHGFY1SKc5d87Gljxr1I5EfD7V0/I6UNU/hxd5wWJg5o0XiqFEor+Rbwf1Q==",
-      "requires": {
-        "stylelint": "^7.13.0"
-      }
-    },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -270,6 +270,59 @@
       "integrity": "sha512-RDavaudOWWta5X11p/q7+nSS+5p+FHCbKWXkHECm1THQ+l1bRk5FUr9Csy78lbqbknqnlF1Lw9qePAG+S4+WgQ==",
       "dev": true
     },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.5.0.tgz",
+      "integrity": "sha512-TZ5HRDFz6CswqBUviPX8EfS+iOoGbclYroZKT3GWGYiGScX0qo6QjHc5uuM7JN920voP2zgCkHgF5SDEVlCtjQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/parser": "1.5.0",
+        "@typescript-eslint/typescript-estree": "1.5.0",
+        "requireindex": "^1.2.0",
+        "tsutils": "^3.7.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.5.0.tgz",
+      "integrity": "sha512-pRWTnJrnxuT0ragdY26hZL+bxqDd4liMlftpH2CBlMPryOIOb1J+MdZuw6R4tIu6bWVdwbHKPTs+Q34LuGvfGw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/typescript-estree": "1.5.0",
+        "eslint-scope": "^4.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+          "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.5.0.tgz",
+      "integrity": "sha512-XqR14d4BcYgxcrpxIwcee7UEjncl9emKc/MgkeUfIk2u85KlsGYyaxC7Zxjmb17JtWERk/NaO+KnBsqgpIXzwA==",
+      "dev": true,
+      "requires": {
+        "lodash.unescape": "4.0.1",
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true
+        }
+      }
+    },
     "JSONStream": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
@@ -1229,6 +1282,12 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -1513,9 +1572,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-4.0.0.tgz",
-      "integrity": "sha512-kWuiJxzV5NwOwZcpyozTzDT5KJhBw292bbYro9Is7BWnbNMg15Gmpluc1CTetiCatF8DRkNvgPAOaSyg+bYr3g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-4.1.0.tgz",
+      "integrity": "sha512-zILwX9/Ocz4SV2vX7ox85AsrAgXV3f2o2gpIicdMIOra48WYqgUnWNH/cR/iHtmD2Vb3dLSC3LiEJnS05Gkw7w==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
@@ -1579,32 +1638,42 @@
       }
     },
     "eslint-plugin-eslint-comments": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.0.1.tgz",
-      "integrity": "sha512-7zU6gCulKVmfG3AZdnvDxzfHaGdvkA8tsLiKbneeI/TlVaulJsRzOyMCctH9QTobKVJ6LIsiJbrkSKkgcFLHxw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.1.1.tgz",
+      "integrity": "sha512-GZDKhOFqJLKlaABX+kdoLskcTINMrVOWxGca54KcFb1QCPd0CLmqgAMRxkkUfGSmN+5NJUMGh7NGccIMcWPSfQ==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5",
-        "ignore": "^3.3.8"
+        "ignore": "^5.0.5"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.6.tgz",
+          "integrity": "sha512-/+hp3kUf/Csa32ktIaj0OlRqQxrgs30n62M90UBpNd9k+ENEch5S+hmbW3DtcJGz3sYFTh4F3A6fQ0q7KWsp4w==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-flowtype": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.2.1.tgz",
-      "integrity": "sha512-1lymqM8Cawxu5xsS8TaCrLWJYUmUdoG4hCfa7yWOhCf0qZn/CvI8FxqkhdOP6bAosBn5zeYxKe3Q/4rfKN8a+A==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.4.2.tgz",
+      "integrity": "sha512-sv6O6fiN3dIwhU4qRxfcyIpbKGVvsxwIQ6vgBLudpQKjH1rEyEFEOjGzGEUBTQP9J8LdTZm37OjiqZ0ZeFOa6g==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.11"
       }
     },
     "eslint-plugin-github": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-1.8.1.tgz",
-      "integrity": "sha512-0bC2ThG0Q4cHYsDsz7GyKQGAoTnE0zxhd+tv1yeUAA1OBinDy2aPxfLnErWAki9dU27XZwvtvqUQoYBxpjGQoQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-1.10.0.tgz",
+      "integrity": "sha512-e99fkqqMALqmnuE3tM4GQKGSt7JSfAgdT1YmznZy4yBcYCvRQyj5urb8iRiPyIf0ERessO4XDzsylxYdt4xXNQ==",
       "dev": true,
       "requires": {
+        "@typescript-eslint/eslint-plugin": "^1.3.0",
+        "@typescript-eslint/parser": "^1.3.0",
         "babel-eslint": ">=8.2.0",
-        "eslint-config-prettier": ">=2.9.0",
+        "eslint-config-prettier": "^4.0.0",
         "eslint-plugin-eslint-comments": ">=3.0.1",
         "eslint-plugin-flowtype": ">=2.49.3",
         "eslint-plugin-graphql": ">=3.0.1",
@@ -1614,20 +1683,17 @@
         "eslint-plugin-prettier": ">=2.6.0",
         "eslint-plugin-react": ">=7.7.0",
         "eslint-plugin-relay": ">=1.0.0",
-        "eslint-plugin-tslint": "^3.1.0",
         "eslint-rule-documentation": ">=1.0.0",
         "inquirer": "^6.0.0",
         "prettier": ">=1.12.0",
         "read-pkg-up": "^4.0.0",
-        "svg-element-attributes": "^1.2.1",
-        "tslint-config-prettier": "^1.17.0",
-        "typescript-eslint-parser": "^21.0.1"
+        "svg-element-attributes": "^1.2.1"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "chardet": {
@@ -1669,12 +1735,12 @@
           }
         },
         "strip-ansi": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -1855,22 +1921,12 @@
       }
     },
     "eslint-plugin-relay": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-relay/-/eslint-plugin-relay-1.0.0.tgz",
-      "integrity": "sha512-Cp/qpdIzryvxnKnCQE4wAbW9z5ix08deOwOx+EAMwkPfGoyyrMitnTAWS6zOmWXlibr2JKEhASlLfCNjyl0E3g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-relay/-/eslint-plugin-relay-1.3.1.tgz",
+      "integrity": "sha512-xGHC4FqWOzxBA5sZKk/hRqTNBOA5HiHZaKXFMwlHoVCVnkf59r4UHqo9Pz/dgLlPks09DvttyFfy7+hP8wN9Lg==",
       "dev": true,
       "requires": {
         "graphql": "^14.0.0"
-      }
-    },
-    "eslint-plugin-tslint": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-tslint/-/eslint-plugin-tslint-3.1.0.tgz",
-      "integrity": "sha512-nEyiP+fpJYi2Qty2KNUs+Pv3IiI73LE2PLR/DbWegzGW7INsm316wmDyn0uFLk74rxaJiixhTGh9B6yrPJfymA==",
-      "dev": true,
-      "requires": {
-        "lodash.memoize": "^4.1.2",
-        "typescript-service": "^2.0.3"
       }
     },
     "eslint-rule-documentation": {
@@ -4842,12 +4898,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
-    "lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-      "dev": true
-    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -5745,13 +5795,14 @@
       }
     },
     "prop-types": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
       }
     },
     "pseudomap": {
@@ -5785,6 +5836,12 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
+    },
+    "react-is": {
+      "version": "16.8.5",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.5.tgz",
+      "integrity": "sha512-sudt2uq5P/2TznPV4Wtdi+Lnq3yaYW8LfvPKLM9BKD8jJNBkxMVyB0C9/GmVhLw7Jbdmndk/73n7XQGeN9A3QQ==",
       "dev": true
     },
     "read-pkg": {
@@ -5953,6 +6010,12 @@
         "caller-path": "^0.1.0",
         "resolve-from": "^1.0.0"
       }
+    },
+    "requireindex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
+      "dev": true
     },
     "resolve": {
       "version": "1.4.0",
@@ -8657,6 +8720,14 @@
         "postcss-value-parser": "^3.3.1"
       }
     },
+    "stylelint-selector-no-utility": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-selector-no-utility/-/stylelint-selector-no-utility-4.0.0.tgz",
+      "integrity": "sha512-C3o1nTwTiRldiLwnN7H99GUJU3xjHGFY1SKc5d87Gljxr1I5EfD7V0/I6UNU/hxd5wWJg5o0XiqFEor+Rbwf1Q==",
+      "requires": {
+        "stylelint": "^7.13.0"
+      }
+    },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -8834,11 +8905,14 @@
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
       "dev": true
     },
-    "tslint-config-prettier": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz",
-      "integrity": "sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==",
-      "dev": true
+    "tsutils": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.9.1.tgz",
+      "integrity": "sha512-hrxVtLtPqQr//p8/msPT1X1UYXUjizqSit5d9AQ5k38TcV38NyecL5xODNxa73cLe/5sdiJ+w1FqzDhRBA/anA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -8869,56 +8943,6 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
-    },
-    "typescript-eslint-parser": {
-      "version": "21.0.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-21.0.2.tgz",
-      "integrity": "sha512-u+pj4RVJBr4eTzj0n5npoXD/oRthvfUCjSKndhNI714MG0mQq2DJw5WP7qmonRNIFgmZuvdDOH3BHm9iOjIAfg==",
-      "dev": true,
-      "requires": {
-        "eslint-scope": "^4.0.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "typescript-estree": "5.3.0"
-      },
-      "dependencies": {
-        "eslint-scope": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-          "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        }
-      }
-    },
-    "typescript-estree": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/typescript-estree/-/typescript-estree-5.3.0.tgz",
-      "integrity": "sha512-Vu0KmYdSCkpae+J48wsFC1ti19Hq3Wi/lODUaE+uesc3gzqhWbZ5itWbsjylLVbjNW4K41RqDzSfnaYNbmEiMQ==",
-      "dev": true,
-      "requires": {
-        "lodash.unescape": "4.0.1",
-        "semver": "5.5.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-          "dev": true
-        }
-      }
-    },
-    "typescript-service": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/typescript-service/-/typescript-service-2.0.3.tgz",
-      "integrity": "sha512-FzRlqRp965UBzGvGwc6rbeko84jLILZrHf++I4cN8usZUB7F8Lh8/WDiCOUvy2l5os+jBWEz4fbYkkj1DhYJcw==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.9.3"
-      }
     },
     "uglify-js": {
       "version": "3.4.9",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "stylelint-selector-no-utility": "4.0.0"
   },
   "peerDependencies": {
-    "@primer/css": "12.x"
+    "@primer/css": ">=12"
   },
   "devDependencies": {
     "@primer/css": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stylelint-config-primer",
   "version": "6.0.0",
   "description": "Sharable stylelint config used by GitHub's CSS",
-  "homepage": "http://primer.style/css/tools",
+  "homepage": "http://primer.style/css/tools/linting",
   "author": "GitHub, Inc.",
   "license": "MIT",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -22,13 +22,14 @@
   },
   "devDependencies": {
     "@primer/css": "^12.2.0",
+    "dedent": "0.7.0",
     "eslint": "4.19.1",
-    "eslint-plugin-github": "^1.8.1",
+    "eslint-plugin-github": "1.10.0",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-jest": "21.15.1",
     "eslint-rule-documentation": "^1.0.11",
     "jest": "^24.0.0",
-    "prettier": "^1.16.4"
+    "prettier": "1.16.4"
   },
   "keywords": [
     "github",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
   "dependencies": {
     "stylelint-no-unsupported-browser-features": "^1.0.0",
     "stylelint-order": "^2.0.0",
-    "stylelint-scss": "3.5.2",
-    "stylelint-selector-no-utility": "4.0.0"
+    "stylelint-scss": "3.5.2"
+  },
+  "peerDependencies": {
+    "@primer/css": "12.x"
   },
   "devDependencies": {
     "@primer/css": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "stylelint-no-unsupported-browser-features": "^1.0.0",
     "stylelint-order": "^2.0.0",
-    "stylelint-scss": "3.5.2"
+    "stylelint-scss": "3.5.2",
+    "stylelint-selector-no-utility": "4.0.0"
   },
   "peerDependencies": {
     "@primer/css": "12.x"

--- a/plugins/no-override.js
+++ b/plugins/no-override.js
@@ -44,13 +44,10 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
       const invalidBundles = Array.isArray(bundles)
         ? `"${bundles.filter(bundle => !availableBundles.includes(bundle)).join('", "')}"`
         : '(not an array)'
-      result.warn(
-        `The "bundles" option must be an array of valid bundles; got: ${invalidBundles}`,
-        {
-          stylelintType: 'invalidOption',
-          stylelintReference: 'https://github.com/primer/stylelint-config-primer#options'
-        }
-      )
+      result.warn(`The "bundles" option must be an array of valid bundles; got: ${invalidBundles}`, {
+        stylelintType: 'invalidOption',
+        stylelintReference: 'https://github.com/primer/stylelint-config-primer#options'
+      })
     }
 
     if (!enabled) {

--- a/plugins/no-override.js
+++ b/plugins/no-override.js
@@ -14,13 +14,13 @@ try {
 }
 
 const messages = stylelint.utils.ruleMessages(ruleName, {
-  rejected: selector => `Avoid styling the utility class selector "${selector}"`
+  rejected: selector => `The class selector "${selector}" is immutable.`
 })
 
 module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
   const {bundles = ['utilities']} = options
 
-  const utilitySelectors = new Set()
+  const immutableSelectors = new Set()
   for (const bundle of bundles) {
     if (!availableBundles.includes(bundle)) {
       throw new Error(`Unknown @primer/css bundle: "${bundle}"!`)
@@ -28,12 +28,12 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
     const {cssstats} = require(`@primer/css/dist/${bundle}`)
     for (const selector of cssstats.selectors.values) {
       for (const classSelector of getClassSelectors(selector)) {
-        utilitySelectors.add(classSelector)
+        immutableSelectors.add(classSelector)
       }
     }
   }
 
-  // console.warn(`Got ${utilitySelectors.size} utility selectors from: "${bundles.join('", "')}"`)
+  // console.warn(`Got ${immutableSelectors.size} immutable selectors from: "${bundles.join('", "')}"`)
 
   return (root, result) => {
     const validOptions = stylelint.utils.validateOptions(result, ruleName, {
@@ -47,7 +47,7 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
 
     root.walkRules(rule => {
       for (const classSelector of getClassSelectors(rule.selector)) {
-        if (utilitySelectors.has(classSelector)) {
+        if (immutableSelectors.has(classSelector)) {
           stylelint.utils.report({
             message: messages.rejected(classSelector),
             node: rule,

--- a/plugins/no-override.js
+++ b/plugins/no-override.js
@@ -1,0 +1,69 @@
+const stylelint = require('stylelint')
+
+const ruleName = 'primer/no-override'
+const CLASS_PATTERN = /(\.[-\w]+)/g
+
+let availableBundles = []
+try {
+  const meta = require('@primer/css/dist/meta.json')
+  availableBundles = Object.keys(meta.bundles)
+} catch (error) {
+  throw new Error(
+    `[${ruleName}] Unable to require('@primer/css/dist/meta.json')! Did you install it as a peerDependency?`
+  )
+}
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+  rejected: selector => `Avoid styling the utility class selector "${selector}"`
+})
+
+module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
+  const {bundles = ['utilities']} = options
+
+  const utilitySelectors = new Set()
+  for (const bundle of bundles) {
+    if (!availableBundles.includes(bundle)) {
+      throw new Error(`Unknown @primer/css bundle: "${bundle}"!`)
+    }
+    const {cssstats} = require(`@primer/css/dist/${bundle}`)
+    for (const selector of cssstats.selectors.values) {
+      for (const classSelector of getClassSelectors(selector)) {
+        utilitySelectors.add(classSelector)
+      }
+    }
+  }
+
+  // console.warn(`Got ${utilitySelectors.size} utility selectors from: "${bundles.join('", "')}"`)
+
+  return (root, result) => {
+    const validOptions = stylelint.utils.validateOptions(result, ruleName, {
+      actual: enabled,
+      possible: [true, false]
+    })
+
+    if (!validOptions) {
+      return
+    }
+
+    root.walkRules(rule => {
+      for (const classSelector of getClassSelectors(rule.selector)) {
+        if (utilitySelectors.has(classSelector)) {
+          stylelint.utils.report({
+            message: messages.rejected(classSelector),
+            node: rule,
+            result,
+            ruleName
+          })
+        }
+      }
+    })
+  }
+})
+
+module.exports.ruleName = ruleName
+module.exports.messages = messages
+
+function getClassSelectors(selector) {
+  const match = selector.match(CLASS_PATTERN)
+  return match ? [...match] : []
+}

--- a/plugins/no-override.js
+++ b/plugins/no-override.js
@@ -3,32 +3,36 @@ const stylelint = require('stylelint')
 const ruleName = 'primer/no-override'
 const CLASS_PATTERN = /(\.[-\w]+)/g
 
+let primerMeta = {}
 let availableBundles = []
 try {
-  const meta = require('@primer/css/dist/meta.json')
-  availableBundles = Object.keys(meta.bundles)
+  primerMeta = require('@primer/css/dist/meta.json')
 } catch (error) {
   throw new Error(
     `[${ruleName}] Unable to require('@primer/css/dist/meta.json')! Did you install it as a peerDependency?`
   )
 }
 
+availableBundles = Object.keys(primerMeta.bundles)
+
 const messages = stylelint.utils.ruleMessages(ruleName, {
-  rejected: selector => `The class selector "${selector}" is immutable.`
+  rejected: selector => `The selector "${selector}" should not be overridden.`
 })
 
 module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
   const {bundles = ['utilities']} = options
 
   const immutableSelectors = new Set()
+  const immutableClassSelectors = new Set()
   for (const bundle of bundles) {
     if (!availableBundles.includes(bundle)) {
       throw new Error(`Unknown @primer/css bundle: "${bundle}"!`)
     }
     const {cssstats} = require(`@primer/css/dist/${bundle}`)
     for (const selector of cssstats.selectors.values) {
+      immutableSelectors.add(selector)
       for (const classSelector of getClassSelectors(selector)) {
-        immutableSelectors.add(classSelector)
+        immutableClassSelectors.add(classSelector)
       }
     }
   }
@@ -45,23 +49,26 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
       return
     }
 
+    const report = (rule, selector) => stylelint.utils.report({
+      message: messages.rejected(selector),
+      node: rule,
+      result,
+      ruleName
+    })
+
     root.walkRules(rule => {
-      for (const classSelector of getClassSelectors(rule.selector)) {
-        if (immutableSelectors.has(classSelector)) {
-          stylelint.utils.report({
-            message: messages.rejected(classSelector),
-            node: rule,
-            result,
-            ruleName
-          })
+      if (immutableSelectors.has(rule.selector)) {
+        report(rule, rule.selector)
+      } else {
+        for (const classSelector of getClassSelectors(rule.selector)) {
+          if (immutableClassSelectors.has(classSelector)) {
+            report(rule, classSelector)
+          }
         }
       }
     })
   }
 })
-
-module.exports.ruleName = ruleName
-module.exports.messages = messages
 
 function getClassSelectors(selector) {
   const match = selector.match(CLASS_PATTERN)

--- a/plugins/no-override.js
+++ b/plugins/no-override.js
@@ -49,12 +49,13 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
       return
     }
 
-    const report = (rule, selector) => stylelint.utils.report({
-      message: messages.rejected(selector),
-      node: rule,
-      result,
-      ruleName
-    })
+    const report = (rule, selector) =>
+      stylelint.utils.report({
+        message: messages.rejected(selector),
+        node: rule,
+        result,
+        ruleName
+      })
 
     root.walkRules(rule => {
       if (immutableSelectors.has(rule.selector)) {

--- a/plugins/selector-no-utility.js
+++ b/plugins/selector-no-utility.js
@@ -1,14 +1,12 @@
 const stylelint = require('stylelint')
 const {rule, ruleName} = require('stylelint-selector-no-utility')
 
-module.exports = stylelint.createPlugin(ruleName, (actual, ...args) => {
-  const deprecatedPlugin = rule(actual, ...args)
+module.exports = stylelint.createPlugin(ruleName, (enabled, ...args) => {
+  const deprecatedPlugin = rule(enabled, ...args)
   return (root, result) => {
-    const validOptions = stylelint.utils.validateOptions(result, ruleName, {actual})
-    if (!validOptions) {
+    if (enabled === false) {
       return
     }
-
     result.warn(
       `'${ruleName}' has been deprecated and will be removed in stylelint-config-primer@7.0.0. Please update your rules to use 'primer/no-override'.`,
       {
@@ -16,7 +14,6 @@ module.exports = stylelint.createPlugin(ruleName, (actual, ...args) => {
         stylelintReference: 'https://github.com/primer/stylelint-config-primer#deprecations'
       }
     )
-
     return deprecatedPlugin(root, result)
   }
 })

--- a/plugins/selector-no-utility.js
+++ b/plugins/selector-no-utility.js
@@ -1,0 +1,22 @@
+const stylelint = require('stylelint')
+const {rule, ruleName} = require('stylelint-selector-no-utility')
+
+module.exports = stylelint.createPlugin(ruleName, (actual, ...args) => {
+  const deprecatedPlugin = rule(actual, ...args)
+  return (root, result) => {
+    const validOptions = stylelint.utils.validateOptions(result, ruleName, {actual})
+    if (!validOptions) {
+      return
+    }
+
+    result.warn(
+      `'${ruleName}' has been deprecated and will be removed in stylelint-config-primer@7.0.0. Please update your rules to use 'primer/no-override'.`,
+      {
+        stylelintType: 'deprecation',
+        stylelintReference: 'https://github.com/primer/stylelint-config-primer#deprecations'
+      }
+    )
+
+    return deprecatedPlugin(root, result)
+  }
+})


### PR DESCRIPTION
🚨**This is a breaking change.** Stylelint configs that reference `primer/selector-no-utility` will need to be updated to use `primer/no-override`, and (depending on the quality of the CSS being linted) there may be lots of errors to fix.

This PR moves [stylelint-selector-no-utility](/primer/stylelint-selector-no-utility) into this repo (as `plugins/no-override.js`), renames it `primer/no-override`, and adds the ability to configure which CSS "bundles" in Primer contain classname selectors (`.mt-6`, `.selected`, etc.) that should be considered _immutable_ and will raise linting errors if they're used to style elements in the linted CSS. In other words:

* If your stylelint config includes:
    ```js
    'primer/no-override': true
    ```
    then the "utilities" bundle (FKA `primer-utilities`) will be searched for classname selectors and all of our core utility classes will be prohibited from being overridden.

* You can configure which bundles are considered immutable with the `bundles` option. For instance, to prohibit marketing utilities (expanded margin and padding classes, etc.) from being overridden, you can do:
    ```js
    `'primer/no-override': [true, {
      bundles: ['utilities', 'marketing-utilities']
    }]
    ```

* If/when we decide that _all_ Primer CSS classnames should be considered immutable, we can just change the default options to `{bundles: ['primer']}`, et voilà!

And because this incorporates the use of `@primer/css` as a peer dependency, it means that we can easily test it with different versions of Primer. It's even compatible with new bundles because it reads their names from [`dist/meta.json`](https://unpkg.com/@primer/css/dist/meta.json), which is generated automatically as part of [the script](https://github.com/primer/css/blob/master/script/dist) that builds the CSS bundles and their stats. 🔮 

Here's some example output from our custom stylesheets in github.com:

```
shawnbot@github:~/primer/stylelint-config-primer% npx stylelint --config ./index.js --quiet ~/github/github/app/assets/stylesheets/custom/github/*.scss

../../github/github/app/assets/stylesheets/custom/github/account.scss
 35:5  ✖  The class selector ".text-right" is immutable.   primer/no-override

../../github/github/app/assets/stylesheets/custom/github/checks.scss
 11:5  ✖  The class selector ".mt-6" is immutable.   primer/no-override

../../github/github/app/assets/stylesheets/custom/github/integrations.scss
 96:3  ✖  The class selector ".lead" is immutable.   primer/no-override

../../github/github/app/assets/stylesheets/custom/github/marketplace.scss
 434:1  ✖  The class selector ".min-width-0" is immutable.   primer/no-override
 577:1  ✖  The class selector ".muted-link" is immutable.    primer/no-override

../../github/github/app/assets/stylesheets/custom/github/pull-request.scss
  84:3  ✖  The class selector ".float-right" is immutable.       primer/no-override
 147:3  ✖  The class selector ".text-emphasized" is immutable.   primer/no-override
 147:3  ✖  The class selector ".text-emphasized" is immutable.   primer/no-override
 214:5  ✖  The class selector ".text-emphasized" is immutable.   primer/no-override

../../github/github/app/assets/stylesheets/custom/github/repository.scss
 353:3  ✖  The class selector ".muted-link" is immutable.   primer/no-override

../../github/github/app/assets/stylesheets/custom/github/setup.scss
 35:3  ✖  The class selector ".lead" is immutable.   primer/no-override
```