### PR TITLE
Release 6.0.0

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,2 @@
-*.log
 coverage/
 node_modules/

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,78 +1,71 @@
-const config = require('../')
-const stylelint = require('stylelint')
+const {lint, extendDefaultConfig} = require('./utils')
 
-const validCss = `
-.selector-x { width: 10%; }
-.selector-y { width: 20%; }
-.selector-z { width: 30%; }
-`
-
-const invalidCss = `
-.foo {
-  color: #fff;
-  top: .2em;
-}
+const SAFE_SCSS_EXAMPLE = `
+  .Component { color: $gray-500; }
 `
 
 describe('stylelint-config-primer', () => {
   it('stylelint runs with our config', () => {
-    return stylelint
-      .lint({
-        code: 'a { font-weight: bold; }',
-        config
-      })
-      .then(data => {
-        expect(data).toBeInstanceOf(Object)
-      })
+    return lint('.bold { font-weight: bold; }').then(data => {
+      expect(data).not.toHaveErrored()
+      expect(data).toHaveResultsLength(1)
+    })
   })
 
   it('produces zero warnings with valid css', () => {
-    return stylelint
-      .lint({
-        code: validCss,
-        config
-      })
-      .then(data => {
-        const {errored, results} = data
-        const {warnings} = results[0]
-        expect(errored).toBeFalsy()
-        expect(warnings).toHaveLength(0)
-      })
+    return lint(`
+      .selector-x { width: 10%; }
+      .selector-y { width: 20%; }
+      .selector-z { width: 30%; }
+    `).then(data => {
+      expect(data).not.toHaveErrored()
+      expect(data).toHaveResultsLength(1)
+      expect(data).toHaveWarningsLength(0)
+    })
   })
 
   it('generates one warning with invalid css', () => {
-    return stylelint
-      .lint({
-        code: invalidCss,
-        config
-      })
-      .then(data => {
-        const {errored, results} = data
-        const {warnings} = results[0]
-        expect(errored).toBeTruthy()
-        expect(warnings).toHaveLength(2)
-        expect(warnings[0].text.trim()).toBe('Expected "top" to come before "color" (order/properties-order)')
-        expect(warnings[1].text.trim()).toBe('Expected a leading zero (number-leading-zero)')
-      })
+    return lint(`
+        .foo {
+          color: #fff;
+          top: .2em;
+        }
+      `).then(data => {
+      expect(data).toHaveErrored()
+      expect(data).toHaveWarningsLength(2)
+      expect(data).toHaveWarnings([
+        'Expected "top" to come before "color" (order/properties-order)',
+        'Expected a leading zero (number-leading-zero)'
+      ])
+    })
   })
 
   it('does not report any deprecations', () => {
-    return stylelint
-      .lint({
-        code: '',
-        config,
-        syntax: 'scss'
+    return lint(SAFE_SCSS_EXAMPLE).then(data => {
+      expect(data).not.toHaveErrored()
+      expect(data).not.toHaveResultsLength(0)
+      expect(data).toHaveDeprecationsLength(0)
+    })
+  })
+
+  it('warns about the planned deprecation of primer/selector-no-utility', () => {
+    return lint(
+      SAFE_SCSS_EXAMPLE,
+      extendDefaultConfig({
+        rules: {
+          'primer/selector-no-utility': true
+        }
       })
-      .then(data => {
-        const {errored, results} = data
-        expect(errored).toBeFalsy()
-        expect(results).not.toHaveLength(0)
-        expect(results[0].deprecations).toHaveLength(
-          0,
-          `Expected there to be no deprecated config warnings. Please fix these:\n\n${results[0].deprecations
-            .map(d => d.text)
-            .join('\n')}`
-        )
-      })
+    ).then(data => {
+      expect(data).not.toHaveErrored()
+      expect(data).not.toHaveResultsLength(0)
+      expect(data).toHaveDeprecationsLength(1)
+      expect(data.results[0].deprecations).toEqual([
+        {
+          text: `'primer/selector-no-utility' has been deprecated and will be removed in stylelint-config-primer@7.0.0. Please update your rules to use 'primer/no-override'.`,
+          reference: 'https://github.com/primer/stylelint-config-primer#deprecations'
+        }
+      ])
+    })
   })
 })

--- a/__tests__/no-override.js
+++ b/__tests__/no-override.js
@@ -1,0 +1,44 @@
+const {lint, extendDefaultConfig} = require('./utils')
+
+describe('primer/no-override', () => {
+  it('reports instances of utility classes', () => {
+    return lint('.text-gray { color: #111; }').then(data => {
+      expect(data).toHaveErrored()
+      expect(data).toHaveWarningsLength(1)
+      expect(data).toHaveWarnings([`The selector ".text-gray" should not be overridden. (primer/no-override)`])
+    })
+  })
+
+  it('reports instances of complete utility selectors', () => {
+    const selector = '.show-on-focus:focus'
+    return lint(`${selector} { color: #f00; }`).then(data => {
+      expect(data).toHaveErrored()
+      expect(data).toHaveWarningsLength(1)
+      expect(data).toHaveWarnings([`The selector "${selector}" should not be overridden. (primer/no-override)`])
+    })
+  })
+
+  it('reports instances of partial utility selectors', () => {
+    const selector = '.show-on-focus'
+    return lint(`.foo ${selector}:focus { color: #f00; }`).then(data => {
+      expect(data).toHaveErrored()
+      expect(data).toHaveWarningsLength(1)
+      expect(data).toHaveWarnings([`The selector "${selector}" should not be overridden. (primer/no-override)`])
+    })
+  })
+
+  it('warns when you pass an invalid bundle name', () => {
+    const config = extendDefaultConfig({
+      rules: {
+        'primer/no-override': [true, {bundles: ['asdf']}]
+      }
+    })
+    return lint('', config).then(data => {
+      expect(data).not.toHaveErrored()
+      expect(data.results[0].invalidOptionWarnings).toHaveLength(1)
+      expect(data.results[0].invalidOptionWarnings[0]).toEqual({
+        text: `The "bundles" option must be an array of valid bundles; got: "asdf"`
+      })
+    })
+  })
+})

--- a/__tests__/no-override.js
+++ b/__tests__/no-override.js
@@ -33,7 +33,7 @@ describe('primer/no-override', () => {
         'primer/no-override': [true, {bundles: ['asdf']}]
       }
     })
-    return lint('', config).then(data => {
+    return lint('.foo { color: #f00; }', config).then(data => {
       expect(data).not.toHaveErrored()
       expect(data.results[0].invalidOptionWarnings).toHaveLength(1)
       expect(data.results[0].invalidOptionWarnings[0]).toEqual({

--- a/__tests__/utils/index.js
+++ b/__tests__/utils/index.js
@@ -1,0 +1,28 @@
+const dedent = require('dedent')
+const stylelint = require('stylelint')
+const {join} = require('path')
+const defaultConfig = require('../..')
+
+module.exports = {
+  lint,
+  defaultConfig,
+  extendDefaultConfig
+}
+
+function extendDefaultConfig(config) {
+  return Object.assign(
+    {
+      extends: join(__dirname, '../..')
+    },
+    config
+  )
+}
+
+function lint(code, config = defaultConfig, options = {}) {
+  return stylelint.lint(
+    Object.assign(options, {
+      code: `${dedent(code).trim()}\n`,
+      config
+    })
+  )
+}

--- a/__tests__/utils/setup.js
+++ b/__tests__/utils/setup.js
@@ -1,0 +1,46 @@
+expect.extend({
+  toHaveErrored(data) {
+    return {
+      pass: data.errored,
+      message: () => `Expected "errored" === ${!data.errored}, but got ${data.errored}:
+- ${data.results[0].warnings.map(warning => warning.text).join('\n- ')}`
+    }
+  },
+
+  toHaveResultsLength(data, length) {
+    return {
+      pass: data.results.length === length,
+      message: () => `Expected results.length === ${length}, but got ${data.results.length}`
+    }
+  },
+
+  toHaveWarningsLength(data, length) {
+    const {warnings} = data.results[0]
+    return {
+      pass: warnings.length === length,
+      message: () => `Expected results[0].warnings.length === ${length}, but got ${warnings.length}:
+- ${warnings.map(warning => warning.text).join('\n- ')}`
+    }
+  },
+
+  toHaveWarnings(data, warningTexts) {
+    const trimmedWarnings = new Set(data.results[0].warnings.map(({text}) => text.trim()))
+    return {
+      pass: warningTexts.every(text => trimmedWarnings.has(text)),
+      message: () => `Expected to find the following warnings:
+- ${warningTexts.filter(text => !trimmedWarnings.has(text)).join('\n- ')}
+
+But got instead:
+- ${data.results[0].warnings.map(warning => warning.text).join('\n- ')}
+`
+    }
+  },
+
+  toHaveDeprecationsLength(data, length) {
+    const {deprecations} = data.results[0]
+    return {
+      pass: deprecations.length === length,
+      message: () => `Expected ${length} deprecations, but got ${deprecations.length}`
+    }
+  }
+})

--- a/index.js
+++ b/index.js
@@ -1,3 +1,10 @@
+// we do this here rather than in each of the plugins
+try {
+  require.resolve('@primer/css')
+} catch (error) {
+  throw new Error(`Unable to require('@primer/css')! Did you install it as a peerDependency?`)
+}
+
 const browsers = require('./browsers')
 const propertyOrder = require('./property-order')
 
@@ -5,8 +12,9 @@ module.exports = {
   plugins: [
     'stylelint-no-unsupported-browser-features',
     'stylelint-order',
-    'stylelint-selector-no-utility',
-    'stylelint-scss'
+    'stylelint-scss',
+    './plugins/no-override',
+    './plugins/selector-no-utility'
   ],
   rules: {
     'at-rule-blacklist': ['extend'],
@@ -92,7 +100,7 @@ module.exports = {
         browsers
       }
     ],
-    'primer/selector-no-utility': true,
+    'primer/no-override': true,
     'property-case': 'lower',
     'property-no-vendor-prefix': true,
     'rule-empty-line-before': [

--- a/index.js
+++ b/index.js
@@ -1,10 +1,3 @@
-// we do this here rather than in each of the plugins
-try {
-  require.resolve('@primer/css')
-} catch (error) {
-  throw new Error(`Unable to require('@primer/css')! Did you install it as a peerDependency?`)
-}
-
 const browsers = require('./browsers')
 const propertyOrder = require('./property-order')
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  collectCoverage: true,
+  collectCoverageFrom: ['src/*.js', 'plugins/*.js'],
+  setupFilesAfterEnv: ['<rootDir>/__tests__/utils/setup.js'],
+  testPathIgnorePatterns: ['/node_modules/', '__tests__/utils']
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -270,6 +270,59 @@
       "integrity": "sha512-RDavaudOWWta5X11p/q7+nSS+5p+FHCbKWXkHECm1THQ+l1bRk5FUr9Csy78lbqbknqnlF1Lw9qePAG+S4+WgQ==",
       "dev": true
     },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.5.0.tgz",
+      "integrity": "sha512-TZ5HRDFz6CswqBUviPX8EfS+iOoGbclYroZKT3GWGYiGScX0qo6QjHc5uuM7JN920voP2zgCkHgF5SDEVlCtjQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/parser": "1.5.0",
+        "@typescript-eslint/typescript-estree": "1.5.0",
+        "requireindex": "^1.2.0",
+        "tsutils": "^3.7.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.5.0.tgz",
+      "integrity": "sha512-pRWTnJrnxuT0ragdY26hZL+bxqDd4liMlftpH2CBlMPryOIOb1J+MdZuw6R4tIu6bWVdwbHKPTs+Q34LuGvfGw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/typescript-estree": "1.5.0",
+        "eslint-scope": "^4.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+          "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.5.0.tgz",
+      "integrity": "sha512-XqR14d4BcYgxcrpxIwcee7UEjncl9emKc/MgkeUfIk2u85KlsGYyaxC7Zxjmb17JtWERk/NaO+KnBsqgpIXzwA==",
+      "dev": true,
+      "requires": {
+        "lodash.unescape": "4.0.1",
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true
+        }
+      }
+    },
     "JSONStream": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
@@ -1229,6 +1282,12 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -1513,9 +1572,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-4.0.0.tgz",
-      "integrity": "sha512-kWuiJxzV5NwOwZcpyozTzDT5KJhBw292bbYro9Is7BWnbNMg15Gmpluc1CTetiCatF8DRkNvgPAOaSyg+bYr3g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-4.1.0.tgz",
+      "integrity": "sha512-zILwX9/Ocz4SV2vX7ox85AsrAgXV3f2o2gpIicdMIOra48WYqgUnWNH/cR/iHtmD2Vb3dLSC3LiEJnS05Gkw7w==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
@@ -1579,32 +1638,42 @@
       }
     },
     "eslint-plugin-eslint-comments": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.0.1.tgz",
-      "integrity": "sha512-7zU6gCulKVmfG3AZdnvDxzfHaGdvkA8tsLiKbneeI/TlVaulJsRzOyMCctH9QTobKVJ6LIsiJbrkSKkgcFLHxw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.1.1.tgz",
+      "integrity": "sha512-GZDKhOFqJLKlaABX+kdoLskcTINMrVOWxGca54KcFb1QCPd0CLmqgAMRxkkUfGSmN+5NJUMGh7NGccIMcWPSfQ==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5",
-        "ignore": "^3.3.8"
+        "ignore": "^5.0.5"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.6.tgz",
+          "integrity": "sha512-/+hp3kUf/Csa32ktIaj0OlRqQxrgs30n62M90UBpNd9k+ENEch5S+hmbW3DtcJGz3sYFTh4F3A6fQ0q7KWsp4w==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-flowtype": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.2.1.tgz",
-      "integrity": "sha512-1lymqM8Cawxu5xsS8TaCrLWJYUmUdoG4hCfa7yWOhCf0qZn/CvI8FxqkhdOP6bAosBn5zeYxKe3Q/4rfKN8a+A==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.4.2.tgz",
+      "integrity": "sha512-sv6O6fiN3dIwhU4qRxfcyIpbKGVvsxwIQ6vgBLudpQKjH1rEyEFEOjGzGEUBTQP9J8LdTZm37OjiqZ0ZeFOa6g==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.11"
       }
     },
     "eslint-plugin-github": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-1.8.1.tgz",
-      "integrity": "sha512-0bC2ThG0Q4cHYsDsz7GyKQGAoTnE0zxhd+tv1yeUAA1OBinDy2aPxfLnErWAki9dU27XZwvtvqUQoYBxpjGQoQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-1.10.0.tgz",
+      "integrity": "sha512-e99fkqqMALqmnuE3tM4GQKGSt7JSfAgdT1YmznZy4yBcYCvRQyj5urb8iRiPyIf0ERessO4XDzsylxYdt4xXNQ==",
       "dev": true,
       "requires": {
+        "@typescript-eslint/eslint-plugin": "^1.3.0",
+        "@typescript-eslint/parser": "^1.3.0",
         "babel-eslint": ">=8.2.0",
-        "eslint-config-prettier": ">=2.9.0",
+        "eslint-config-prettier": "^4.0.0",
         "eslint-plugin-eslint-comments": ">=3.0.1",
         "eslint-plugin-flowtype": ">=2.49.3",
         "eslint-plugin-graphql": ">=3.0.1",
@@ -1614,20 +1683,17 @@
         "eslint-plugin-prettier": ">=2.6.0",
         "eslint-plugin-react": ">=7.7.0",
         "eslint-plugin-relay": ">=1.0.0",
-        "eslint-plugin-tslint": "^3.1.0",
         "eslint-rule-documentation": ">=1.0.0",
         "inquirer": "^6.0.0",
         "prettier": ">=1.12.0",
         "read-pkg-up": "^4.0.0",
-        "svg-element-attributes": "^1.2.1",
-        "tslint-config-prettier": "^1.17.0",
-        "typescript-eslint-parser": "^21.0.1"
+        "svg-element-attributes": "^1.2.1"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "chardet": {
@@ -1669,12 +1735,12 @@
           }
         },
         "strip-ansi": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -1855,22 +1921,12 @@
       }
     },
     "eslint-plugin-relay": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-relay/-/eslint-plugin-relay-1.0.0.tgz",
-      "integrity": "sha512-Cp/qpdIzryvxnKnCQE4wAbW9z5ix08deOwOx+EAMwkPfGoyyrMitnTAWS6zOmWXlibr2JKEhASlLfCNjyl0E3g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-relay/-/eslint-plugin-relay-1.3.1.tgz",
+      "integrity": "sha512-xGHC4FqWOzxBA5sZKk/hRqTNBOA5HiHZaKXFMwlHoVCVnkf59r4UHqo9Pz/dgLlPks09DvttyFfy7+hP8wN9Lg==",
       "dev": true,
       "requires": {
         "graphql": "^14.0.0"
-      }
-    },
-    "eslint-plugin-tslint": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-tslint/-/eslint-plugin-tslint-3.1.0.tgz",
-      "integrity": "sha512-nEyiP+fpJYi2Qty2KNUs+Pv3IiI73LE2PLR/DbWegzGW7INsm316wmDyn0uFLk74rxaJiixhTGh9B6yrPJfymA==",
-      "dev": true,
-      "requires": {
-        "lodash.memoize": "^4.1.2",
-        "typescript-service": "^2.0.3"
       }
     },
     "eslint-rule-documentation": {
@@ -4842,12 +4898,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
-    "lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-      "dev": true
-    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -5745,13 +5795,14 @@
       }
     },
     "prop-types": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
       }
     },
     "pseudomap": {
@@ -5785,6 +5836,12 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
+    },
+    "react-is": {
+      "version": "16.8.5",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.5.tgz",
+      "integrity": "sha512-sudt2uq5P/2TznPV4Wtdi+Lnq3yaYW8LfvPKLM9BKD8jJNBkxMVyB0C9/GmVhLw7Jbdmndk/73n7XQGeN9A3QQ==",
       "dev": true
     },
     "read-pkg": {
@@ -5953,6 +6010,12 @@
         "caller-path": "^0.1.0",
         "resolve-from": "^1.0.0"
       }
+    },
+    "requireindex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
+      "dev": true
     },
     "resolve": {
       "version": "1.4.0",
@@ -8842,11 +8905,14 @@
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
       "dev": true
     },
-    "tslint-config-prettier": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz",
-      "integrity": "sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==",
-      "dev": true
+    "tsutils": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.9.1.tgz",
+      "integrity": "sha512-hrxVtLtPqQr//p8/msPT1X1UYXUjizqSit5d9AQ5k38TcV38NyecL5xODNxa73cLe/5sdiJ+w1FqzDhRBA/anA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -8877,56 +8943,6 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
-    },
-    "typescript-eslint-parser": {
-      "version": "21.0.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-21.0.2.tgz",
-      "integrity": "sha512-u+pj4RVJBr4eTzj0n5npoXD/oRthvfUCjSKndhNI714MG0mQq2DJw5WP7qmonRNIFgmZuvdDOH3BHm9iOjIAfg==",
-      "dev": true,
-      "requires": {
-        "eslint-scope": "^4.0.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "typescript-estree": "5.3.0"
-      },
-      "dependencies": {
-        "eslint-scope": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-          "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        }
-      }
-    },
-    "typescript-estree": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/typescript-estree/-/typescript-estree-5.3.0.tgz",
-      "integrity": "sha512-Vu0KmYdSCkpae+J48wsFC1ti19Hq3Wi/lODUaE+uesc3gzqhWbZ5itWbsjylLVbjNW4K41RqDzSfnaYNbmEiMQ==",
-      "dev": true,
-      "requires": {
-        "lodash.unescape": "4.0.1",
-        "semver": "5.5.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-          "dev": true
-        }
-      }
-    },
-    "typescript-service": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/typescript-service/-/typescript-service-2.0.3.tgz",
-      "integrity": "sha512-FzRlqRp965UBzGvGwc6rbeko84jLILZrHf++I4cN8usZUB7F8Lh8/WDiCOUvy2l5os+jBWEz4fbYkkj1DhYJcw==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.9.3"
-      }
     },
     "uglify-js": {
       "version": "3.4.9",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stylelint-config-primer",
   "version": "6.0.0",
   "description": "Sharable stylelint config used by GitHub's CSS",
-  "homepage": "http://primer.style/css/tools",
+  "homepage": "http://primer.style/css/tools/linting",
   "author": "GitHub, Inc.",
   "license": "MIT",
   "main": "index.js",
@@ -17,15 +17,19 @@
     "stylelint-scss": "3.5.2",
     "stylelint-selector-no-utility": "4.0.0"
   },
+  "peerDependencies": {
+    "@primer/css": ">=12"
+  },
   "devDependencies": {
     "@primer/css": "^12.2.0",
+    "dedent": "0.7.0",
     "eslint": "4.19.1",
-    "eslint-plugin-github": "^1.8.1",
+    "eslint-plugin-github": "1.10.0",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-jest": "21.15.1",
     "eslint-rule-documentation": "^1.0.11",
     "jest": "^24.0.0",
-    "prettier": "^1.16.4"
+    "prettier": "1.16.4"
   },
   "keywords": [
     "github",

--- a/plugins/no-override.js
+++ b/plugins/no-override.js
@@ -1,19 +1,8 @@
 const stylelint = require('stylelint')
+const {requirePrimerFile} = require('../src/primer')
 
 const ruleName = 'primer/no-override'
 const CLASS_PATTERN = /(\.[-\w]+)/g
-
-let primerMeta = {}
-let availableBundles = []
-try {
-  primerMeta = require('@primer/css/dist/meta.json')
-} catch (error) {
-  throw new Error(
-    `[${ruleName}] Unable to require('@primer/css/dist/meta.json')! Did you install it as a peerDependency?`
-  )
-}
-
-availableBundles = Object.keys(primerMeta.bundles)
 
 const messages = stylelint.utils.ruleMessages(ruleName, {
   rejected: selector => `The selector "${selector}" should not be overridden.`
@@ -21,6 +10,9 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
 
 module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
   const {bundles = ['utilities']} = options
+
+  const primerMeta = requirePrimerFile('dist/meta.json')
+  const availableBundles = Object.keys(primerMeta.bundles)
 
   const immutableSelectors = new Set()
   const immutableClassSelectors = new Set()

--- a/plugins/no-override.js
+++ b/plugins/no-override.js
@@ -20,7 +20,7 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
     if (!availableBundles.includes(bundle)) {
       continue
     }
-    const stats = require(`@primer/css/dist/stats/${bundle}.json`)
+    const stats = requirePrimerFile(`dist/stats/${bundle}.json`)
     for (const selector of stats.selectors.values) {
       immutableSelectors.add(selector)
       for (const classSelector of getClassSelectors(selector)) {

--- a/plugins/no-override.js
+++ b/plugins/no-override.js
@@ -9,6 +9,10 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
 })
 
 module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
+  if (!enabled) {
+    return noop
+  }
+
   const {bundles = ['utilities']} = options
 
   const primerMeta = requirePrimerFile('dist/meta.json')
@@ -71,4 +75,7 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
 function getClassSelectors(selector) {
   const match = selector.match(CLASS_PATTERN)
   return match ? [...match] : []
+}
+
+function noop() {
 }

--- a/plugins/no-override.js
+++ b/plugins/no-override.js
@@ -77,5 +77,4 @@ function getClassSelectors(selector) {
   return match ? [...match] : []
 }
 
-function noop() {
-}
+function noop() {}

--- a/plugins/no-override.js
+++ b/plugins/no-override.js
@@ -1,0 +1,82 @@
+const stylelint = require('stylelint')
+
+const ruleName = 'primer/no-override'
+const CLASS_PATTERN = /(\.[-\w]+)/g
+
+let primerMeta = {}
+let availableBundles = []
+try {
+  primerMeta = require('@primer/css/dist/meta.json')
+} catch (error) {
+  throw new Error(
+    `[${ruleName}] Unable to require('@primer/css/dist/meta.json')! Did you install it as a peerDependency?`
+  )
+}
+
+availableBundles = Object.keys(primerMeta.bundles)
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+  rejected: selector => `The selector "${selector}" should not be overridden.`
+})
+
+module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
+  const {bundles = ['utilities']} = options
+
+  const immutableSelectors = new Set()
+  const immutableClassSelectors = new Set()
+  for (const bundle of bundles) {
+    if (!availableBundles.includes(bundle)) {
+      continue
+    }
+    const stats = require(`@primer/css/dist/stats/${bundle}.json`)
+    for (const selector of stats.selectors.values) {
+      immutableSelectors.add(selector)
+      for (const classSelector of getClassSelectors(selector)) {
+        immutableClassSelectors.add(classSelector)
+      }
+    }
+  }
+
+  // console.warn(`Got ${immutableSelectors.size} immutable selectors from: "${bundles.join('", "')}"`)
+
+  return (root, result) => {
+    if (!Array.isArray(bundles) || bundles.some(bundle => !availableBundles.includes(bundle))) {
+      const invalidBundles = Array.isArray(bundles)
+        ? `"${bundles.filter(bundle => !availableBundles.includes(bundle)).join('", "')}"`
+        : '(not an array)'
+      result.warn(`The "bundles" option must be an array of valid bundles; got: ${invalidBundles}`, {
+        stylelintType: 'invalidOption',
+        stylelintReference: 'https://github.com/primer/stylelint-config-primer#options'
+      })
+    }
+
+    if (!enabled) {
+      return
+    }
+
+    const report = (rule, selector) =>
+      stylelint.utils.report({
+        message: messages.rejected(selector),
+        node: rule,
+        result,
+        ruleName
+      })
+
+    root.walkRules(rule => {
+      if (immutableSelectors.has(rule.selector)) {
+        report(rule, rule.selector)
+      } else {
+        for (const classSelector of getClassSelectors(rule.selector)) {
+          if (immutableClassSelectors.has(classSelector)) {
+            report(rule, classSelector)
+          }
+        }
+      }
+    })
+  }
+})
+
+function getClassSelectors(selector) {
+  const match = selector.match(CLASS_PATTERN)
+  return match ? [...match] : []
+}

--- a/plugins/selector-no-utility.js
+++ b/plugins/selector-no-utility.js
@@ -5,12 +5,11 @@ let rule = () => null
 let selectorNoUtility
 try {
   selectorNoUtility = require('stylelint-selector-no-utility')
+  rule = selectorNoUtility.rule
 } catch (error) {
   // eslint-disable-next-line no-console
   console.warn(`Unable to require('stylelint-selector-no-utility'): ${error}`)
 }
-
-rule = selectorNoUtility.rule
 
 module.exports = stylelint.createPlugin(ruleName, (enabled, ...args) => {
   const deprecatedPlugin = rule(enabled, ...args)

--- a/plugins/selector-no-utility.js
+++ b/plugins/selector-no-utility.js
@@ -1,5 +1,16 @@
 const stylelint = require('stylelint')
-const {rule, ruleName} = require('stylelint-selector-no-utility')
+
+const ruleName = 'primer/selector-no-utility'
+let rule = () => null
+let selectorNoUtility
+try {
+  selectorNoUtility = require('stylelint-selector-no-utility')
+} catch (error) {
+  // eslint-disable-next-line no-console
+  console.warn(`Unable to require('stylelint-selector-no-utility'): ${error}`)
+}
+
+rule = selectorNoUtility.rule
 
 module.exports = stylelint.createPlugin(ruleName, (enabled, ...args) => {
   const deprecatedPlugin = rule(enabled, ...args)

--- a/plugins/selector-no-utility.js
+++ b/plugins/selector-no-utility.js
@@ -1,0 +1,19 @@
+const stylelint = require('stylelint')
+const {rule, ruleName} = require('stylelint-selector-no-utility')
+
+module.exports = stylelint.createPlugin(ruleName, (enabled, ...args) => {
+  const deprecatedPlugin = rule(enabled, ...args)
+  return (root, result) => {
+    if (enabled === false) {
+      return
+    }
+    result.warn(
+      `'${ruleName}' has been deprecated and will be removed in stylelint-config-primer@7.0.0. Please update your rules to use 'primer/no-override'.`,
+      {
+        stylelintType: 'deprecation',
+        stylelintReference: 'https://github.com/primer/stylelint-config-primer#deprecations'
+      }
+    )
+    return deprecatedPlugin(root, result)
+  }
+})

--- a/plugins/selector-no-utility.js
+++ b/plugins/selector-no-utility.js
@@ -1,18 +1,22 @@
 const stylelint = require('stylelint')
 
 const ruleName = 'primer/selector-no-utility'
-let rule = () => null
-let selectorNoUtility
-try {
-  selectorNoUtility = require('stylelint-selector-no-utility')
-  rule = selectorNoUtility.rule
-} catch (error) {
-  // eslint-disable-next-line no-console
-  console.warn(`Unable to require('stylelint-selector-no-utility'): ${error}`)
-}
 
 module.exports = stylelint.createPlugin(ruleName, (enabled, ...args) => {
-  const deprecatedPlugin = rule(enabled, ...args)
+  if (!enabled) {
+    return noop
+  }
+
+  let selectorNoUtility
+  try {
+    selectorNoUtility = require('stylelint-selector-no-utility')
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn(`Unable to require('stylelint-selector-no-utility'): ${error}`)
+    return noop
+  }
+
+  const deprecatedPlugin = selectorNoUtility.rule(enabled, ...args)
   return (root, result) => {
     if (enabled === false) {
       return
@@ -27,3 +31,6 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, ...args) => {
     return deprecatedPlugin(root, result)
   }
 })
+
+function noop() {
+}

--- a/plugins/selector-no-utility.js
+++ b/plugins/selector-no-utility.js
@@ -32,5 +32,4 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, ...args) => {
   }
 })
 
-function noop() {
-}
+function noop() {}

--- a/src/primer.js
+++ b/src/primer.js
@@ -1,0 +1,24 @@
+const {existsSync} = require('fs')
+const {join} = require('path')
+
+module.exports = {
+  getPrimerModuleDir,
+  requirePrimerFile
+}
+
+function getPrimerModuleDir() {
+  const cwd = process.cwd()
+  const localPackageJson = join(cwd, 'package.json')
+  if (existsSync(localPackageJson)) {
+    const {name} = require(localPackageJson)
+    if (name === '@primer/css') {
+      return cwd
+    }
+  }
+  return '@primer/css'
+}
+
+function requirePrimerFile(path) {
+  const fullPath = join(getPrimerModuleDir(), path)
+  return require(fullPath)
+}


### PR DESCRIPTION
### :boom: Breaking changes
* The config now uses `primer/no-override` instead of `primer/selector-no-utility`. See #25 for more info.
* `@primer/css` is now a required peer dependency, because we want this to work with different versions of Primer.

### :rocket: Features
* `primer/no-override` is a new rule that replaces `primer/selector-no-utility` and makes it possible to configure files or directories with options that allow or prevent overrides of selectors from different Primer CSS "bundles". See #25 for more info.

### :house: Internal
* There are more extensive tests, additional `expect()` matchers, and test utilities that make it easy to set rule options in each test.