### PR TITLE
Release 7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-primer",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-primer",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Sharable stylelint config used by GitHub's CSS",
   "homepage": "http://primer.style/css/tools/linting",
   "author": "GitHub, Inc.",


### PR DESCRIPTION
Welp, turns out 6.0.0 was already released, so we're bumping to 7.0.0 with the changes in #27:

### :boom: Breaking changes
* The config now uses `primer/no-override` instead of `primer/selector-no-utility`. See #25 for more info.
* `@primer/css` is now a required peer dependency, because we want this to work with different versions of Primer.

### :rocket: Features
* `primer/no-override` is a new rule that replaces `primer/selector-no-utility` and makes it possible to configure files or directories with options that allow or prevent overrides of selectors from different Primer CSS "bundles". See #25 for more info.

### :house: Internal
* There are more extensive tests, additional `expect()` matchers, and test utilities that make it easy to set rule options in each test.