### PR TITLE
Allow any version of Primer

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "stylelint-selector-no-utility": "4.0.0"
   },
   "peerDependencies": {
-    "@primer/css": ">=12"
+    "@primer/css": "*"
   },
   "devDependencies": {
     "@primer/css": "^12.2.0",


### PR DESCRIPTION
This PR makes it so that any version of Primer, also Canary (0.0.0.....) works.