### PR TITLE
Improve primer/no-override to match classes, better reporting

### DIFF
--- a/__tests__/no-override.js
+++ b/__tests__/no-override.js
@@ -5,7 +5,7 @@ describe('primer/no-override', () => {
     return lint('.text-gray { color: #111; }').then(data => {
       expect(data).toHaveErrored()
       expect(data).toHaveWarningsLength(1)
-      expect(data).toHaveWarnings([`The selector ".text-gray" should not be overridden. (primer/no-override)`])
+      expect(data).toHaveWarnings([`".text-gray" should not be overridden (found in utilities). (primer/no-override)`])
     })
   })
 
@@ -14,7 +14,7 @@ describe('primer/no-override', () => {
     return lint(`${selector} { color: #f00; }`).then(data => {
       expect(data).toHaveErrored()
       expect(data).toHaveWarningsLength(1)
-      expect(data).toHaveWarnings([`The selector "${selector}" should not be overridden. (primer/no-override)`])
+      expect(data).toHaveWarnings([`"${selector}" should not be overridden (found in utilities). (primer/no-override)`])
     })
   })
 
@@ -23,7 +23,7 @@ describe('primer/no-override', () => {
     return lint(`.foo ${selector}:focus { color: #f00; }`).then(data => {
       expect(data).toHaveErrored()
       expect(data).toHaveWarningsLength(1)
-      expect(data).toHaveWarnings([`The selector "${selector}" should not be overridden. (primer/no-override)`])
+      expect(data).toHaveWarnings([`"${selector}" should not be overridden in ".foo ${selector}:focus" (found in utilities). (primer/no-override)`])
     })
   })
 

--- a/__tests__/no-override.js
+++ b/__tests__/no-override.js
@@ -23,7 +23,9 @@ describe('primer/no-override', () => {
     return lint(`.foo ${selector}:focus { color: #f00; }`).then(data => {
       expect(data).toHaveErrored()
       expect(data).toHaveWarningsLength(1)
-      expect(data).toHaveWarnings([`"${selector}" should not be overridden in ".foo ${selector}:focus" (found in utilities). (primer/no-override)`])
+      expect(data).toHaveWarnings([
+        `"${selector}" should not be overridden in ".foo ${selector}:focus" (found in utilities). (primer/no-override)`
+      ])
     })
   })
 

--- a/plugins/no-override.js
+++ b/plugins/no-override.js
@@ -22,7 +22,7 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
       continue
     }
     const stats = requirePrimerFile(`dist/stats/${bundle}.json`)
-    const selectors = stats.selectors.values.filter(selector => !!CLASS_PATTERN.test(selector))
+    const selectors = stats.selectors.values.filter(selector => CLASS_PATTERN.test(selector))
     for (const selector of selectors) {
       immutableSelectors.set(selector, bundle)
       for (const classSelector of getClassSelectors(selector)) {


### PR DESCRIPTION
This updates our `primer/no-overrides` rule to focus on class selectors specifically, as including non-class selectors produces a lot of false positives in (_cough_) some large custom CSS codebases. I've also reworked the error messages so that they're easier to read, and so that you can `sort` the output to more easily find what you're looking for:

```python
#                                          ⇣ this is the full selector in violation
✖ ".text-gray" should not be overridden in ".foo .text-gray" (found in utilities)
# ⇡ this is the immutable part                      this is the bundle ⇡
```