### PR TITLE
Release 8.1.0

### DIFF
--- a/__tests__/no-override.js
+++ b/__tests__/no-override.js
@@ -1,11 +1,25 @@
 const {lint, extendDefaultConfig} = require('./utils')
 
 describe('primer/no-override', () => {
+  it(`doesn't run when disabled`, () => {
+    const config = extendDefaultConfig({
+      rules: {
+        'primer/no-override': false
+      }
+    })
+    return lint(`.text-gray { color: #111; }`, config).then(data => {
+      expect(data).not.toHaveErrored()
+      expect(data).toHaveWarningsLength(0)
+    })
+  })
+
   it('reports instances of utility classes', () => {
     return lint('.text-gray { color: #111; }').then(data => {
       expect(data).toHaveErrored()
       expect(data).toHaveWarningsLength(1)
-      expect(data).toHaveWarnings([`".text-gray" should not be overridden (found in utilities). (primer/no-override)`])
+      expect(data).toHaveWarnings([
+        `".text-gray" should not be overridden (defined in @primer/css/utilities). (primer/no-override)`
+      ])
     })
   })
 
@@ -14,7 +28,9 @@ describe('primer/no-override', () => {
     return lint(`${selector} { color: #f00; }`).then(data => {
       expect(data).toHaveErrored()
       expect(data).toHaveWarningsLength(1)
-      expect(data).toHaveWarnings([`"${selector}" should not be overridden (found in utilities). (primer/no-override)`])
+      expect(data).toHaveWarnings([
+        `"${selector}" should not be overridden (defined in @primer/css/utilities). (primer/no-override)`
+      ])
     })
   })
 
@@ -24,22 +40,110 @@ describe('primer/no-override', () => {
       expect(data).toHaveErrored()
       expect(data).toHaveWarningsLength(1)
       expect(data).toHaveWarnings([
-        `"${selector}" should not be overridden in ".foo ${selector}:focus" (found in utilities). (primer/no-override)`
+        `"${selector}" should not be overridden in ".foo ${selector}:focus" (defined in @primer/css/utilities). (primer/no-override)`
       ])
     })
   })
 
-  it('warns when you pass an invalid bundle name', () => {
-    const config = extendDefaultConfig({
+  it('only reports class selectors', () => {
+    const config = {
+      plugins: [require.resolve('../plugins/no-override')],
       rules: {
-        'primer/no-override': [true, {bundles: ['asdf']}]
+        'primer/no-override': [true, {bundles: ['base']}]
       }
-    })
-    return lint('.foo { color: #f00; }', config).then(data => {
+    }
+    return lint(`body { color: #f00; }`, config).then(data => {
       expect(data).not.toHaveErrored()
-      expect(data.results[0].invalidOptionWarnings).toHaveLength(1)
-      expect(data.results[0].invalidOptionWarnings[0]).toEqual({
-        text: `The "bundles" option must be an array of valid bundles; got: "asdf"`
+      expect(data).toHaveWarningsLength(0)
+    })
+  })
+
+  describe('ignoreSelectors option', () => {
+    it('ignores selectors listed as strings', () => {
+      const config = extendDefaultConfig({
+        rules: {
+          'primer/no-override': [
+            true,
+            {
+              bundles: ['utilities'],
+              ignoreSelectors: ['.px-4']
+            }
+          ]
+        }
+      })
+      return lint(`.px-4 { margin: 0 4px !important; }`, config).then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data).toHaveWarningsLength(0)
+      })
+    })
+
+    it('ignores selectors listed as regular expressions', () => {
+      const config = extendDefaultConfig({
+        rules: {
+          'primer/no-override': [
+            true,
+            {
+              bundles: ['utilities'],
+              ignoreSelectors: [/\.px-[0-9]/]
+            }
+          ]
+        }
+      })
+      return lint(`.px-4 { margin: 0 4px !important; }`, config).then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data).toHaveWarningsLength(0)
+      })
+    })
+
+    it('ignores selectors when ignoreSelectors is a function', () => {
+      const config = extendDefaultConfig({
+        rules: {
+          'primer/no-override': [
+            true,
+            {
+              bundles: ['utilities'],
+              ignoreSelectors: selector => selector === '.px-4'
+            }
+          ]
+        }
+      })
+      return lint(`.px-4 { margin: 0 4px !important; }`, config).then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data).toHaveWarningsLength(0)
+      })
+    })
+  })
+
+  describe('invalid options', () => {
+    it('warns when you bundles is not an array', () => {
+      const config = extendDefaultConfig({
+        rules: {
+          'primer/no-override': [true, {bundles: 'derp'}]
+        }
+      })
+      return lint('.foo { color: #f00; }', config).then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data.results[0].invalidOptionWarnings).toEqual([
+          {
+            text: `The "bundles" option must be an array of valid bundles; got: (not an array)`
+          }
+        ])
+      })
+    })
+
+    it('warns when you pass an invalid bundle name', () => {
+      const config = extendDefaultConfig({
+        rules: {
+          'primer/no-override': [true, {bundles: ['asdf']}]
+        }
+      })
+      return lint('.foo { color: #f00; }', config).then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data.results[0].invalidOptionWarnings).toEqual([
+          {
+            text: `The "bundles" option must be an array of valid bundles; got: "asdf"`
+          }
+        ])
       })
     })
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-primer",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-primer",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Sharable stylelint config used by GitHub's CSS",
   "homepage": "http://primer.style/css/tools/linting",
   "author": "GitHub, Inc.",


### PR DESCRIPTION
### :rocket: New features
- [x] #43 Add `ignoreSelectors` option to `primer/no-override`, which takes an array of strings and/or regular expressions or a function to ignore (pass) matched selectors

### :bug: Bug fixes
- [x] #43 Improve reporting of class selectors (only) in `primer/no-override`