### PR TITLE
Add primer/no-unused-vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Within your [stylelint config object](http://stylelint.io/user-guide/configurati
 
 * [stylelint-scss](https://github.com/kristerkari/stylelint-scss): A collection of SCSS specific linting rules for stylelint
   * [scss/selector-no-redundant-nesting-selector](https://github.com/kristerkari/stylelint-scss/blob/master/src/rules/selector-no-redundant-nesting-selector/README.md): Disallow redundant nesting selectors (`&`).
-* [primer/no-override](./plugins/#primer-no-override): Prohibits custom styles that target Primer CSS selectors.
-* [primer/no-unused-vars](./plugins/primer-no-unused-vars): Warns about SCSS variables that are declared by not used in your local files.
+* [primer/no-override](./plugins/#primerno-override): Prohibits custom styles that target Primer CSS selectors.
+* [primer/no-unused-vars](./plugins/primerno-unused-vars): Warns about SCSS variables that are declared by not used in your local files.
 
 ### Configured lints
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Within your [stylelint config object](http://stylelint.io/user-guide/configurati
 
 * [stylelint-scss](https://github.com/kristerkari/stylelint-scss): A collection of SCSS specific linting rules for stylelint
   * [scss/selector-no-redundant-nesting-selector](https://github.com/kristerkari/stylelint-scss/blob/master/src/rules/selector-no-redundant-nesting-selector/README.md): Disallow redundant nesting selectors (`&`).
-* [primer/no-override](plugins/no-override.js): Prohibits custom styles that target Primer CSS selectors.
+* [primer/no-override](./plugins/#primer-no-override): Prohibits custom styles that target Primer CSS selectors.
+* [primer/no-unused-vars](./plugins/primer-no-unused-vars): Warns about SCSS variables that are declared by not used in your local files.
 
 ### Configured lints
 

--- a/__tests__/__fixtures__/has-unused-vars.scss
+++ b/__tests__/__fixtures__/has-unused-vars.scss
@@ -1,0 +1,2 @@
+$used-elsewhere: 640px;
+$unused: 9999;

--- a/__tests__/__fixtures__/uses-vars.scss
+++ b/__tests__/__fixtures__/uses-vars.scss
@@ -1,0 +1,5 @@
+@import "./has-unused-vars.scss";
+
+.card {
+  max-width: $used-elsewhere;
+}

--- a/__tests__/no-unused-vars.js
+++ b/__tests__/no-unused-vars.js
@@ -1,0 +1,62 @@
+const {join} = require('path')
+const stylelint = require('stylelint')
+
+const fixture = (...path) => join(__dirname, '__fixtures__', ...path)
+const ruleName = 'primer/no-unused-vars'
+const pluginPath = require.resolve('../plugins/no-unused-vars')
+
+describe('primer/no-unused-vars', () => {
+  it('finds unused vars', () => {
+    const config = {
+      plugins: [pluginPath],
+      rules: {
+        [ruleName]: [true, {files: fixture('*.scss')}]
+      }
+    }
+    return stylelint
+      .lint({
+        files: fixture('has-unused-vars.scss'),
+        config
+      })
+      .then(data => {
+        expect(data).toHaveErrored()
+        expect(data).toHaveWarnings([`The variable "$unused" is not referenced. (${ruleName})`])
+      })
+  })
+
+  it(`doesn't run when disabled`, () => {
+    const config = {
+      plugins: [pluginPath],
+      rules: {
+        [ruleName]: false
+      }
+    }
+    return stylelint
+      .lint({
+        files: fixture('has-unused-vars.scss'),
+        config
+      })
+      .then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data).toHaveWarningsLength(0)
+      })
+  })
+
+  it(`talks a lot with {verbose: true}`, () => {
+    const config = {
+      plugins: [pluginPath],
+      rules: {
+        [ruleName]: [true, {files: fixture('*.scss'), verbose: true}]
+      }
+    }
+    return stylelint
+      .lint({
+        files: fixture('*.scss'),
+        config
+      })
+      .then(data => {
+        expect(data).toHaveErrored()
+        expect(data).toHaveWarnings([`The variable "$unused" is not referenced. (${ruleName})`])
+      })
+  })
+})

--- a/index.js
+++ b/index.js
@@ -2,7 +2,13 @@ const browsers = require('./browsers')
 const propertyOrder = require('./property-order')
 
 module.exports = {
-  plugins: ['stylelint-no-unsupported-browser-features', 'stylelint-order', 'stylelint-scss', './plugins/no-override'],
+  plugins: [
+    'stylelint-no-unsupported-browser-features',
+    'stylelint-order',
+    'stylelint-scss',
+    './plugins/no-override',
+    './plugins/no-unused-vars'
+  ],
   rules: {
     'at-rule-blacklist': ['extend'],
     'at-rule-name-case': 'lower',
@@ -88,6 +94,9 @@ module.exports = {
       }
     ],
     'primer/no-override': true,
+    // unused vars are not necessarily an error, since they may be referenced
+    // in other projects
+    'primer/no-unused-vars': [true, {severity: 'warning'}],
     'property-case': 'lower',
     'property-no-vendor-prefix': true,
     'rule-empty-line-before': [

--- a/package-lock.json
+++ b/package-lock.json
@@ -7917,6 +7917,11 @@
         "string-width": "^2.1.1"
       }
     },
+    "tap-map": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tap-map/-/tap-map-1.0.0.tgz",
+      "integrity": "sha512-qYUKYf/zPDpj9xL8eb3mBcGN+8qHcW4Yvem02SapcBZAw9PQHHrozIu+bma3o5MdDbcmgKK88hv5rCTGR8RZfA=="
+    },
     "test-exclude": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1775,7 +1775,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -1960,7 +1959,6 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
       "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
-      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
@@ -1974,7 +1972,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -3524,8 +3521,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -3789,9 +3785,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.3.tgz",
+      "integrity": "sha512-VupOxR91xcGojfINrzMqrvlyYbBs39sXIrWa7YdaQWeBudOlvKEGvCczMfJPgnuwHE/zyH1M6J+IUP6cgDVyxg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -3842,7 +3838,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -3864,8 +3859,7 @@
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-      "dev": true
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "has-value": {
       "version": "1.0.0",
@@ -4158,8 +4152,7 @@
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
     "is-ci": {
       "version": "2.0.0",
@@ -4191,8 +4184,7 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-decimal": {
       "version": "1.0.3",
@@ -4304,7 +4296,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -4329,7 +4320,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.0"
       }
@@ -5864,8 +5854,7 @@
     "object-keys": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
-      "dev": true
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -6559,6 +6548,14 @@
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
+      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "requires": {
+        "define-properties": "^1.1.2"
       }
     },
     "regexpp": {
@@ -7321,6 +7318,18 @@
             "ansi-regex": "^3.0.0"
           }
         }
+      }
+    },
+    "string.prototype.matchall": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-3.0.1.tgz",
+      "integrity": "sha512-NSiU0ILQr9PQ1SZmM1X327U5LsM+KfDTassJfqN1al1+0iNpKzmQ4BfXOJwRnTEqv8nKJ67mFpqRoPaGWwvy5A==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "regexp.prototype.flags": "^1.2.0"
       }
     },
     "string_decoder": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "stylelint-no-unsupported-browser-features": "^1.0.0",
     "stylelint-order": "^2.0.0",
-    "stylelint-scss": "^3.10.0"
+    "stylelint-scss": "^3.10.0",
+    "tap-map": "^1.0.0"
   },
   "peerDependencies": {
     "@primer/css": "*"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "repository": "https://github.com/primer/stylelint-config-primer",
   "dependencies": {
+    "string.prototype.matchall": "^3.0.1",
     "stylelint-no-unsupported-browser-features": "^1.0.0",
     "stylelint-order": "^2.0.0",
     "stylelint-scss": "^3.10.0",

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -102,3 +102,4 @@ and references in its options:
   project layouts.
 
 [primer css]: https://primer.style/css
+[globby]: https://www.npmjs.com/package/globby

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -35,7 +35,7 @@ CSS]. By default, it will only fail selectors that target utility classes:
 You can further constrain overrides to exclude _any_ class selector in Primer
 by providing additional names in the `bundles` option:
 
-```
+```js
 // stylelint.config.js
 module.exports = {
   // ...

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,104 @@
+# Primer stylelint plugins
+This directory contains all of our custom stylelint plugins. These were
+intended for use with [Primer CSS] and GitHub projects, but you may find them
+useful elsewhere.
+
+## Usage
+If you're using or extending `stylelint-config-primer` already, then you're
+using all of these plugins by default. See [`index.js`](../index.js) for the
+config defaults.
+
+If you're _not_ using or extending `stylelint-config-primer`, you can still
+reference the plugins by referencing their module paths like so:
+
+```js
+// stylelint.config.js
+module.exports = {
+  plugins: [
+    'stylelint-config-primer/plugins/no-override',
+    'stylelint-config-primer/plugins/no-unused-vars'
+  ]
+}
+```
+
+## Plugins
+
+### `primer/no-override`
+This plugin helps prohibits "overriding" class selectors defined in [Primer
+CSS]. By default, it will only fail selectors that target utility classes:
+
+```scss
+// FAIL
+.mt-0 { /* literally anything */ }
+```
+
+You can further constrain overrides to exclude _any_ class selector in Primer
+by providing additional names in the `bundles` option:
+
+```
+// stylelint.config.js
+module.exports = {
+  // ...
+  rules: {
+    'primer/no-override': [
+      true,
+      {
+        bundles: ['utilities', core', 'product', 'marketing']
+      }
+    ]
+  }
+}
+```
+
+### `primer/no-unused-vars`
+This plugin helps you find SCSS variables that _may_ not be used, and can be
+safely deleted. It works by scanning all of the SCSS files in your project and
+looking for anything that appears to be either a Sass variable declaration or
+reference:
+
+```scss
+    $name: value;
+/**      ↑
+ *  The colon is what makes this a declaration */
+
+/* Anything starting with a $ and followed by word chars or hyphens
+ * and _not_ followed by a colon is considered a reference: */
+
+    margin: $value;
+/**               ↑
+ *                Not a colon */
+    padding: $value 1px;
+/**                ↑
+ *                 Not a colon */
+
+@media screen and (max-width: $break-lg) {
+/**                                    ↑
+ *                                     Also not a colon */
+```
+
+Armed with a list of all the variable declarations and references, the linting
+rule walks all of the declarations in the file being linted, finds any that
+look like declarations (using the same pattern as the project-wide scan), and
+generates a warning for any that have zero references in the files it's
+scanned.
+
+Because there isn't any good way for a stylelint plugin to know all of the
+files being linted, it needs to be told where to find all of the declarations
+and references in its options:
+
+* `files` a single path, glob, or array of paths and globs, that tells the
+  plugin which files to scan relative to the current working directory. The
+  default is `['**/*.scss', '!node_modules']`, which tells [globby] to find all
+  the `.scss` files recursively and ignore the `node_modules` directory.
+
+* `variablePattern` is a regular expression that matches a single variable in
+  either a source file string or the `prop` of a postcss `decl` node. The
+  default matches Sass/SCSS variables: `/\$[-\w]/g`. Note that the `g`
+  ("global") flag is _required_ to match multiple variable references on a
+  single line.
+
+* `verbose` is a boolean that enables chatty `console.warn()` messages telling
+  you what the plugin found, which can aid in debugging more complicated
+  project layouts.
+
+[primer css]: https://primer.style/css

--- a/plugins/no-unused-vars.js
+++ b/plugins/no-unused-vars.js
@@ -8,7 +8,7 @@ const ruleName = 'primer/no-unused-vars'
 
 const cwd = process.cwd()
 const COLON = ':'
-const SCSS_VARIABLE_PATTERN = /(\$[-a-z0-9]+)/gi
+const SCSS_VARIABLE_PATTERN = /(\$[-\w]+)/g
 
 const messages = stylelint.utils.ruleMessages(ruleName, {
   rejected: name => `The variable "${name}" is not referenced.`
@@ -29,8 +29,7 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
 
   return (root, result) => {
     root.walkDecls(decl => {
-      for (const match of matchAll(decl.prop, variablePattern)) {
-        const name = match[1]
+      for (const [name] of matchAll(decl.prop, variablePattern)) {
         if (!refs.has(name)) {
           stylelint.utils.report({
             message: messages.rejected(name),
@@ -59,7 +58,7 @@ function getCachedVariables(options, log) {
       const css = readFileSync(file, 'utf8')
       for (const match of matchAll(css, variablePattern)) {
         const after = css.substr(match.index + match[0].length)
-        const name = match[1]
+        const name = match[0]
         if (after.startsWith(COLON)) {
           decs.tap(name, set).add(file)
         } else {

--- a/plugins/no-unused-vars.js
+++ b/plugins/no-unused-vars.js
@@ -1,0 +1,96 @@
+const TapMap = require('tap-map')
+const stylelint = require('stylelint')
+const globby = require('globby')
+const {readFileSync} = require('fs')
+
+const ruleName = 'primer/no-unused-vars'
+
+const cwd = process.cwd()
+const COLON = ':'
+const SCSS_VARIABLE_PATTERN = /(\$[-a-z0-9]+)/gi
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+  rejected: name => `The variable "${name}" is not referenced.`
+})
+
+const cache = new TapMap()
+
+module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
+  if (!enabled) {
+    return noop
+  }
+
+  const {files = ['**/*.scss', '!node_modules'], variablePattern = SCSS_VARIABLE_PATTERN, verbose = false} = options
+  // eslint-disable-next-line no-console
+  const log = verbose ? (...args) => console.warn(...args) : noop
+  const cacheOptions = {files, variablePattern, cwd}
+  const {refs} = getCachedVariables(cacheOptions, log)
+
+  return (root, result) => {
+    root.walkDecls(decl => {
+      for (const match of decl.prop.matchAll(variablePattern)) {
+        const name = match[1]
+        if (!refs.has(name)) {
+          stylelint.utils.report({
+            message: messages.rejected(name),
+            node: decl,
+            result,
+            ruleName
+          })
+        } else {
+          const path = stripCwd(decl.source.input.file)
+          log(`${name} declared in ${path} ref'd in ${pluralize(refs.get(name).size, 'file')}`)
+        }
+      }
+    })
+  }
+})
+
+function getCachedVariables(options, log) {
+  const key = JSON.stringify(options)
+  return cache.tap(key, () => {
+    const {files, variablePattern} = options
+    const decs = new TapMap()
+    const refs = new TapMap()
+
+    log(`Looking for variables in ${files} ...`)
+    for (const file of globby.sync(files)) {
+      const css = readFileSync(file, 'utf8')
+      for (const match of css.matchAll(variablePattern)) {
+        const after = css.substr(match.index + match[0].length)
+        const name = match[1]
+        if (after.startsWith(COLON)) {
+          decs.tap(name, set).add(file)
+        } else {
+          refs.tap(name, set).add(file)
+        }
+      }
+    }
+    log(`Found ${decs.size} declarations, ${pluralize(refs.size, 'reference')}.`)
+
+    for (const [name, files] of decs.entries()) {
+      const fileRefs = refs.get(name)
+      if (fileRefs) {
+        log(`variable "${name}" declared in ${pluralize(files.size, 'file')}, ref'd in ${fileRefs.size}`)
+      } else {
+        log(`[!] variable "${name}" declared in ${Array.from(files)[0]} is not referenced`)
+      }
+    }
+
+    return {decs, refs}
+  })
+}
+
+function noop() {}
+
+function set() {
+  return new Set()
+}
+
+function stripCwd(path) {
+  return path.startsWith(cwd) ? path.substr(cwd.length + 1) : path
+}
+
+function pluralize(num, str, plural = `${str}s`) {
+  return num === 1 ? `${num} ${str}` : `${num} ${plural}`
+}

--- a/plugins/no-unused-vars.js
+++ b/plugins/no-unused-vars.js
@@ -1,6 +1,7 @@
 const TapMap = require('tap-map')
-const stylelint = require('stylelint')
 const globby = require('globby')
+const matchAll = require('string.prototype.matchall')
+const stylelint = require('stylelint')
 const {readFileSync} = require('fs')
 
 const ruleName = 'primer/no-unused-vars'
@@ -28,7 +29,7 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
 
   return (root, result) => {
     root.walkDecls(decl => {
-      for (const match of decl.prop.matchAll(variablePattern)) {
+      for (const match of matchAll(decl.prop, variablePattern)) {
         const name = match[1]
         if (!refs.has(name)) {
           stylelint.utils.report({
@@ -56,7 +57,7 @@ function getCachedVariables(options, log) {
     log(`Looking for variables in ${files} ...`)
     for (const file of globby.sync(files)) {
       const css = readFileSync(file, 'utf8')
-      for (const match of css.matchAll(variablePattern)) {
+      for (const match of matchAll(css, variablePattern)) {
         const after = css.substr(match.index + match[0].length)
         const name = match[1]
         if (after.startsWith(COLON)) {


### PR DESCRIPTION
[:eyes: Check out the plugin docs!](https://github.com/primer/stylelint-config-primer/blob/no-unused-vars/plugins/README.md)

I looked around for stylelint rules to catch unused variables and didn't find any. Of note:

* https://github.com/kristerkari/stylelint-scss/issues/276 was closed and (AFAIK) never addressed
* [`find-unused-sass-variables`](https://github.com/XhmikosR/find-unused-sass-variables) exists, and works! But it's not a stylelint plugin, so we can't really use it here. However, we can use it to check my work on this PR!

Anyway, this adds a `primer/no-unused-vars` stylelint rule that scours all the source files in the optional `files` option (one or more "globs"; the default is `['**/*.scss', '!node_modules']`, so it looks for all `.scss` files that aren't in your node modules), finds every instance of what look like SCSS variable declarations (`$foo: bar`) and references (`width: $foo`), then checks all the declarations in the file being linted to see if there are any variables known _not_ to be declared in the scoured files.

In other words, given:

```scss
// a.scss
$small: 320px;
$medium: 640px;
$large: 1024px;

// b.scss
.small { max-width: $small; }
.large { max-width: $large; }
```

and:

```js
npx stylelint --config=stylelint-config-primer *.scss
```

You should see the following warning:

```
a.scss
 2:1  ⚠  The variable "$medium" is not referenced.   primer/no-unused-vars
```

Unused variables aren't errors by default (you can make them with the `severity: 'error'` option) because it's very possible that they may be used by _consumers_ of the files being linted, as is the case with `@primer/css`. In the case of github/github, what we probably want to do is run it with a config like:

```js
{
  extends: ['stylelint-config-primer'],
  rules: {
    'primer/no-unused-vars': [true, {
      severity: 'error',
      files: [
        'app/assets/stylesheets/**/*.scss',
        'node_modules/@primer/css/**/*.scss',
        '!node_modules/@primer/css/node_modules' // ugh
      ]
    }]
  }
}
```

Sure enough, when run `npx stylelint --quiet` with that config in github/github, we get some candidates for removal:

```
app/assets/stylesheets/custom/mobile/variables.scss
 14:1  ✖  The variable "$mobile-color-active-background" is not referenced.   primer/no-unused-vars
 26:1  ✖  The variable "$delete" is not referenced.                           primer/no-unused-vars
 29:1  ✖  The variable "$headerLinkColor" is not referenced.                  primer/no-unused-vars
 30:1  ✖  The variable "$headerHeight" is not referenced.                     primer/no-unused-vars
 33:1  ✖  The variable "$header-dark-bg" is not referenced.                   primer/no-unused-vars
 36:1  ✖  The variable "$header-dark-mail-status" is not referenced.          primer/no-unused-vars

app/assets/stylesheets/custom/github/variables.scss
  7:1  ✖  The variable "$integrations-bg-color" is not referenced.   primer/no-unused-vars
 13:1  ✖  The variable "$lang-color-radius" is not referenced.       primer/no-unused-vars
 15:1  ✖  The variable "$treeBorder" is not referenced.              primer/no-unused-vars
 19:1  ✖  The variable "$plan-box-padding" is not referenced.        primer/no-unused-vars
```

and you can spot-check each of those to be sure, e.g.

```
$ ack treeBorder app/assets/stylesheets 
app/assets/stylesheets/custom/github/variables.scss
15:$treeBorder: #cacaca;
$
```

(Whoever chose `#cacaca` 😂 )

As soon as I get this passing CI, I'll open it up for review!