### PR TITLE
Release 8.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Within your [stylelint config object](http://stylelint.io/user-guide/configurati
   * [scss/selector-no-redundant-nesting-selector](https://github.com/kristerkari/stylelint-scss/blob/master/src/rules/selector-no-redundant-nesting-selector/README.md): Disallow redundant nesting selectors (`&`).
 * [primer/no-override](./plugins/#primerno-override): Prohibits custom styles that target Primer CSS selectors.
 * [primer/no-unused-vars](./plugins/primerno-unused-vars): Warns about SCSS variables that are declared by not used in your local files.
+* [primer/variables](./plugins/primervariables): Constrains certain CSS properties to Primer CSS variables for consistency of color, typography, whitespace, etc.
 
 ### Configured lints
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Within your [stylelint config object](http://stylelint.io/user-guide/configurati
 
 * [stylelint-scss](https://github.com/kristerkari/stylelint-scss): A collection of SCSS specific linting rules for stylelint
   * [scss/selector-no-redundant-nesting-selector](https://github.com/kristerkari/stylelint-scss/blob/master/src/rules/selector-no-redundant-nesting-selector/README.md): Disallow redundant nesting selectors (`&`).
-* [primer/no-override](plugins/no-override.js): Prohibits custom styles that target Primer CSS selectors.
+* [primer/no-override](./plugins/#primerno-override): Prohibits custom styles that target Primer CSS selectors.
+* [primer/no-unused-vars](./plugins/primerno-unused-vars): Warns about SCSS variables that are declared by not used in your local files.
 
 ### Configured lints
 

--- a/__tests__/__fixtures__/has-unused-vars.scss
+++ b/__tests__/__fixtures__/has-unused-vars.scss
@@ -1,0 +1,2 @@
+$used-elsewhere: 640px;
+$unused: 9999;

--- a/__tests__/__fixtures__/uses-vars.scss
+++ b/__tests__/__fixtures__/uses-vars.scss
@@ -1,0 +1,5 @@
+@import "./has-unused-vars.scss";
+
+.card {
+  max-width: $used-elsewhere;
+}

--- a/__tests__/no-unused-vars.js
+++ b/__tests__/no-unused-vars.js
@@ -1,0 +1,62 @@
+const {join} = require('path')
+const stylelint = require('stylelint')
+
+const fixture = (...path) => join(__dirname, '__fixtures__', ...path)
+const ruleName = 'primer/no-unused-vars'
+const pluginPath = require.resolve('../plugins/no-unused-vars')
+
+describe('primer/no-unused-vars', () => {
+  it('finds unused vars', () => {
+    const config = {
+      plugins: [pluginPath],
+      rules: {
+        [ruleName]: [true, {files: fixture('*.scss')}]
+      }
+    }
+    return stylelint
+      .lint({
+        files: fixture('has-unused-vars.scss'),
+        config
+      })
+      .then(data => {
+        expect(data).toHaveErrored()
+        expect(data).toHaveWarnings([`The variable "$unused" is not referenced. (${ruleName})`])
+      })
+  })
+
+  it(`doesn't run when disabled`, () => {
+    const config = {
+      plugins: [pluginPath],
+      rules: {
+        [ruleName]: false
+      }
+    }
+    return stylelint
+      .lint({
+        files: fixture('has-unused-vars.scss'),
+        config
+      })
+      .then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data).toHaveWarningsLength(0)
+      })
+  })
+
+  it(`talks a lot with {verbose: true}`, () => {
+    const config = {
+      plugins: [pluginPath],
+      rules: {
+        [ruleName]: [true, {files: fixture('*.scss'), verbose: true}]
+      }
+    }
+    return stylelint
+      .lint({
+        files: fixture('*.scss'),
+        config
+      })
+      .then(data => {
+        expect(data).toHaveErrored()
+        expect(data).toHaveWarnings([`The variable "$unused" is not referenced. (${ruleName})`])
+      })
+  })
+})

--- a/__tests__/variables.js
+++ b/__tests__/variables.js
@@ -1,0 +1,362 @@
+const dedent = require('dedent')
+const stylelint = require('stylelint')
+const ruleName = 'primer/variables'
+const pluginPath = require.resolve('../plugins/variables')
+
+const configWithOptions = args => ({
+  plugins: [pluginPath],
+  rules: {
+    [ruleName]: args
+  }
+})
+
+describe(ruleName, () => {
+  it(`doesn't run when disabled`, () => {
+    return stylelint
+      .lint({
+        code: `.x { color: #f00; }`,
+        config: configWithOptions(false)
+      })
+      .then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data).toHaveWarningsLength(0)
+      })
+  })
+
+  it(`doesn't reject properties we don't care about`, () => {
+    return stylelint
+      .lint({
+        code: `.x { display: block; }`,
+        config: configWithOptions(false)
+      })
+      .then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data).toHaveWarningsLength(0)
+      })
+  })
+
+  describe('spacing values', () => {
+    it('suggests exact replacements for spacer value', () => {
+      return stylelint
+        .lint({
+          code: `.x { margin: 4px; }`,
+          config: configWithOptions(true)
+        })
+        .then(data => {
+          expect(data).toHaveErrored()
+          expect(data).toHaveWarningsLength(1)
+          expect(data).toHaveWarnings([`Please use "$spacer-1" instead of "4px". (${ruleName})`])
+        })
+    })
+  })
+
+  describe('font-size', () => {
+    it('reports color properties w/o variables', () => {
+      return stylelint
+        .lint({
+          code: dedent`
+            .x { font-size: 11px; }
+            .y { font-size: $spacer-3; }
+          `,
+          config: configWithOptions(true)
+        })
+        .then(data => {
+          expect(data).toHaveErrored()
+          expect(data).toHaveWarnings([
+            `Please use a font-size variable instead of "11px". (${ruleName})`,
+            `Please use a font-size variable instead of "$spacer-3". (${ruleName})`
+          ])
+        })
+    })
+
+    it('does not report font size variables', () => {
+      return stylelint
+        .lint({
+          code: dedent`
+            .h1 { font-size: $h1-size; }
+            .h2 { font-size: $h2-size; }
+            .h3-mobile { font-size: $h3-size-mobile; }
+            small { font-size: $font-size-small; }
+          `,
+          config: configWithOptions(true)
+        })
+        .then(data => {
+          expect(data).not.toHaveErrored()
+          expect(data).toHaveWarningsLength(0)
+        })
+    })
+
+    it('can fix them', () => {
+      return stylelint
+        .lint({
+          code: dedent`
+            .x { font-size: 32px; }
+          `,
+          config: configWithOptions(true, {verbose: true}),
+          fix: true
+        })
+        .then(data => {
+          expect(data).not.toHaveErrored()
+          expect(data).toHaveWarningsLength(0)
+          expect(data.output).toEqual(dedent`
+            .x { font-size: $h1-size; }
+          `)
+        })
+    })
+  })
+
+  describe('color properties', () => {
+    it('reports color properties w/o variables', () => {
+      return stylelint
+        .lint({
+          code: `.x { color: #f00; }`,
+          config: configWithOptions(true)
+        })
+        .then(data => {
+          expect(data).toHaveErrored()
+          expect(data).toHaveWarningsLength(1)
+          expect(data).toHaveWarnings([`Please use a text color variable instead of "#f00". (${ruleName})`])
+        })
+    })
+
+    it('does not report color properties with allowed values', () => {
+      return stylelint
+        .lint({
+          code: `.x { background-color: transparent; }`,
+          config: configWithOptions(true)
+        })
+        .then(data => {
+          expect(data).not.toHaveErrored()
+          expect(data).toHaveWarningsLength(0)
+        })
+    })
+  })
+
+  it('reports properties with wrong variable usage', () => {
+    return stylelint
+      .lint({
+        code: `.x { background-color: $red; }`,
+        config: configWithOptions(true)
+      })
+      .then(data => {
+        expect(data).toHaveErrored()
+        expect(data).toHaveWarningsLength(1)
+        expect(data).toHaveWarnings([`Please use a background color variable instead of "$red". (${ruleName})`])
+      })
+  })
+
+  describe('borders', () => {
+    it('reports compound border properties', () => {
+      return stylelint
+        .lint({
+          code: `
+            .foo { border: $red; }
+          `,
+          config: configWithOptions(true)
+        })
+        .then(data => {
+          expect(data).toHaveErrored()
+          expect(data).toHaveWarnings([`Please use a border variable instead of "$red". (${ruleName})`])
+        })
+    })
+
+    it('reports multiple border properties', () => {
+      return stylelint
+        .lint({
+          code: `
+            .foo { border: 1px solid gray; }
+          `,
+          config: configWithOptions(true)
+        })
+        .then(data => {
+          expect(data).toHaveErrored()
+          expect(data).toHaveWarnings([
+            `Please use "$border-width" instead of "1px". (${ruleName})`,
+            `Please use "$border-style" instead of "solid". (${ruleName})`,
+            `Please use a border color variable instead of "gray". (${ruleName})`
+          ])
+        })
+    })
+
+    it('recognizes function calls as whole tokens', () => {
+      return stylelint
+        .lint({
+          code: `
+            .foo { border: calc($spacer-2 + var(--derp)) $border-style rgba($border-gray-dark, 50%); }
+          `,
+          config: configWithOptions(true)
+        })
+        .then(data => {
+          expect(data).toHaveErrored()
+          expect(data).toHaveWarnings([
+            `Please use a border width variable instead of "calc($spacer-2 + var(--derp))". (${ruleName})`,
+            `Please use a border color variable instead of "rgba($border-gray-dark, 50%)". (${ruleName})`
+          ])
+        })
+    })
+  })
+
+  it('does not report properties with valid variables', () => {
+    return stylelint
+      .lint({
+        code: `.x { background-color: $bg-red; }`,
+        config: configWithOptions(true)
+      })
+      .then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data).toHaveWarningsLength(0)
+      })
+  })
+
+  describe('autofix', () => {
+    it('fixes spacer variables', () => {
+      return stylelint
+        .lint({
+          code: `.x { margin-top: 8px; }`,
+          config: configWithOptions(true),
+          fix: true
+        })
+        .then(data => {
+          expect(data).not.toHaveErrored()
+          expect(data).toHaveWarningsLength(0)
+          expect(data.output).toEqual(`.x { margin-top: $spacer-2; }`)
+        })
+    })
+
+    it('fixes border variables', () => {
+      return stylelint
+        .lint({
+          code: dedent`
+            .x { border: 1px solid $gray-300; }
+          `,
+          config: configWithOptions(true),
+          fix: true
+        })
+        .then(data => {
+          expect(data).not.toHaveErrored()
+          expect(data).toHaveWarningsLength(0)
+          expect(data.output).toEqual(dedent`
+            .x { border: $border-width $border-style $border-gray-dark; }
+          `)
+        })
+    })
+
+    it('fixes border radius', () => {
+      return stylelint
+        .lint({
+          code: dedent`
+            .x { border-radius: 3px; }
+            .y {
+              border-top-left-radius: 3px;
+              border-bottom-left-radius: 3px;
+            }
+          `,
+          config: configWithOptions(true),
+          fix: true
+        })
+        .then(data => {
+          expect(data).not.toHaveErrored()
+          expect(data).toHaveWarningsLength(0)
+          expect(data.output).toEqual(dedent`
+            .x { border-radius: $border-radius; }
+            .y {
+              border-top-left-radius: $border-radius;
+              border-bottom-left-radius: $border-radius;
+            }
+          `)
+        })
+    })
+
+    it('fixes text colors', () => {
+      return stylelint
+        .lint({
+          code: dedent`
+            .x { color: $red-600; }
+            .y { color: $purple; }
+          `,
+          config: configWithOptions(true),
+          fix: true
+        })
+        .then(data => {
+          expect(data).not.toHaveErrored()
+          expect(data).toHaveWarningsLength(0)
+          expect(data.output).toEqual(dedent`
+            .x { color: $text-red; }
+            .y { color: $text-purple; }
+          `)
+        })
+    })
+
+    it('fixes padding', () => {
+      return stylelint
+        .lint({
+          code: dedent`
+            .x { padding: 4px 8px 0; }
+          `,
+          config: configWithOptions(true, {verbose: true}),
+          fix: true
+        })
+        .then(data => {
+          expect(data).not.toHaveErrored()
+          expect(data).toHaveWarningsLength(0)
+          expect(data.output).toEqual(dedent`
+            .x { padding: $spacer-1 $spacer-2 0; }
+          `)
+        })
+    })
+
+    it('fixes margin', () => {
+      return stylelint
+        .lint({
+          code: dedent`
+            .x { margin-top: 4px; margin-right: 8px; }
+          `,
+          config: configWithOptions(true, {verbose: true}),
+          fix: true
+        })
+        .then(data => {
+          expect(data).not.toHaveErrored()
+          expect(data).toHaveWarningsLength(0)
+          expect(data.output).toEqual(dedent`
+            .x { margin-top: $spacer-1; margin-right: $spacer-2; }
+          `)
+        })
+    })
+
+    it('preserves !important', () => {
+      return stylelint
+        .lint({
+          code: dedent`
+            .x { margin: 8px !important; }
+          `,
+          config: configWithOptions(true, {verbose: true}),
+          fix: true
+        })
+        .then(data => {
+          expect(data).not.toHaveErrored()
+          expect(data).toHaveWarningsLength(0)
+          expect(data.output).toEqual(dedent`
+            .x { margin: $spacer-2 !important; }
+          `)
+        })
+    })
+
+    it('fixes background colors', () => {
+      return stylelint
+        .lint({
+          code: dedent`
+            .x { background-color: $red-500; }
+          `,
+          config: configWithOptions(true, {verbose: true}),
+          fix: true
+        })
+        .then(data => {
+          expect(data).not.toHaveErrored()
+          expect(data).toHaveWarningsLength(0)
+          expect(data.output).toEqual(dedent`
+            .x { background-color: $bg-red; }
+          `)
+        })
+    })
+  })
+})

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ module.exports = {
     'stylelint-order',
     'stylelint-scss',
     './plugins/no-override',
-    './plugins/no-unused-vars'
+    './plugins/no-unused-vars',
+    './plugins/variables'
   ],
   rules: {
     'at-rule-blacklist': ['extend'],

--- a/index.js
+++ b/index.js
@@ -2,7 +2,13 @@ const browsers = require('./browsers')
 const propertyOrder = require('./property-order')
 
 module.exports = {
-  plugins: ['stylelint-no-unsupported-browser-features', 'stylelint-order', 'stylelint-scss', './plugins/no-override'],
+  plugins: [
+    'stylelint-no-unsupported-browser-features',
+    'stylelint-order',
+    'stylelint-scss',
+    './plugins/no-override',
+    './plugins/no-unused-vars'
+  ],
   rules: {
     'at-rule-blacklist': ['extend'],
     'at-rule-name-case': 'lower',
@@ -88,6 +94,9 @@ module.exports = {
       }
     ],
     'primer/no-override': true,
+    // unused vars are not necessarily an error, since they may be referenced
+    // in other projects
+    'primer/no-unused-vars': [true, {severity: 'warning'}],
     'property-case': 'lower',
     'property-no-vendor-prefix': true,
     'rule-empty-line-before': [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1775,7 +1775,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -1974,7 +1973,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -3524,8 +3522,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -3842,7 +3839,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -3864,8 +3860,7 @@
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-      "dev": true
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "has-value": {
       "version": "1.0.0",
@@ -4158,8 +4153,7 @@
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
     "is-ci": {
       "version": "2.0.0",
@@ -4191,8 +4185,7 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-decimal": {
       "version": "1.0.3",
@@ -4304,7 +4297,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -4329,7 +4321,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.0"
       }
@@ -5861,11 +5852,15 @@
         }
       }
     },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
+    },
     "object-keys": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
-      "dev": true
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -6559,6 +6554,14 @@
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
+      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "requires": {
+        "define-properties": "^1.1.2"
       }
     },
     "regexpp": {
@@ -7323,6 +7326,60 @@
         }
       }
     },
+    "string.prototype.matchall": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-3.0.2.tgz",
+      "integrity": "sha512-hsRe42jQ8+OJej2GVjhnSVodQ3NQgHV0FDD6dW7ZTM22J4uIbuYiAADCCc1tfyN7ocEl/KUUbudM36E2tZcF8w==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.14.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "regexp.prototype.flags": "^1.2.0"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
+          "integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
+          "requires": {
+            "es-to-primitive": "^1.2.0",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.0",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.6.0",
+            "object-keys": "^1.1.1",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+        }
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -7916,6 +7973,11 @@
         "slice-ansi": "1.0.0",
         "string-width": "^2.1.1"
       }
+    },
+    "tap-map": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tap-map/-/tap-map-1.0.0.tgz",
+      "integrity": "sha512-qYUKYf/zPDpj9xL8eb3mBcGN+8qHcW4Yvem02SapcBZAw9PQHHrozIu+bma3o5MdDbcmgKK88hv5rCTGR8RZfA=="
     },
     "test-exclude": {
       "version": "5.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3789,9 +3789,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.2.tgz",
+      "integrity": "sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -8149,9 +8149,9 @@
       },
       "dependencies": {
         "commander": {
-          "version": "2.20.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "version": "2.20.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
+          "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==",
           "dev": true,
           "optional": true
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -768,13 +768,12 @@
       "dev": true
     },
     "anymatch": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-      "dev": true,
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
       "requires": {
-        "micromatch": "^3.1.4",
-        "normalize-path": "^2.1.1"
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
       }
     },
     "argparse": {
@@ -1148,30 +1147,11 @@
       }
     },
     "braces": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "requires": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
+        "fill-range": "^7.0.1"
       }
     },
     "browser-process-hrtime": {
@@ -2769,24 +2749,11 @@
       }
     },
     "fill-range": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
+        "to-regex-range": "^5.0.1"
       }
     },
     "find-up": {
@@ -4758,11 +4725,30 @@
         "walker": "^1.0.7"
       },
       "dependencies": {
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "dev": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          }
+        },
         "graceful-fs": {
           "version": "4.1.15",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
           "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
           "dev": true
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
         }
       }
     },
@@ -5568,6 +5554,65 @@
         "regex-not": "^1.0.0",
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.2"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
       }
     },
     "mime-db": {
@@ -5770,13 +5815,9 @@
       }
     },
     "normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
-      "requires": {
-        "remove-trailing-separator": "^1.0.1"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -6893,6 +6934,16 @@
         "walker": "~1.0.5"
       },
       "dependencies": {
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "dev": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          }
+        },
         "cross-spawn": {
           "version": "6.0.5",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -6928,6 +6979,15 @@
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
           }
         },
         "semver": {
@@ -8102,12 +8162,18 @@
       }
     },
     "to-regex-range": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "^7.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        }
       }
     },
     "tough-cookie": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-primer",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-primer",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "description": "Sharable stylelint config used by GitHub's CSS",
   "homepage": "http://primer.style/css/tools/linting",
   "author": "GitHub, Inc.",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
   },
   "repository": "https://github.com/primer/stylelint-config-primer",
   "dependencies": {
+    "string.prototype.matchall": "^3.0.1",
     "stylelint-no-unsupported-browser-features": "^1.0.0",
     "stylelint-order": "^2.0.0",
-    "stylelint-scss": "^3.10.0"
+    "stylelint-scss": "^3.10.0",
+    "tap-map": "^1.0.0"
   },
   "peerDependencies": {
     "@primer/css": "*"

--- a/package.json
+++ b/package.json
@@ -6,12 +6,21 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "main": "index.js",
+  "repository": "primer/stylelint-config-primer",
+  "keywords": [
+    "github",
+    "primer",
+    "css",
+    "stylelint-config",
+    "stylelint"
+  ],
   "scripts": {
     "test": "jest",
     "lint": "eslint ."
   },
-  "repository": "https://github.com/primer/stylelint-config-primer",
   "dependencies": {
+    "anymatch": "^3.1.1",
+    "braces": "^3.0.2",
     "string.prototype.matchall": "^3.0.1",
     "stylelint-no-unsupported-browser-features": "^1.0.0",
     "stylelint-order": "^2.0.0",
@@ -31,12 +40,5 @@
     "eslint-rule-documentation": "^1.0.11",
     "jest": "24.8.0",
     "prettier": "1.16.4"
-  },
-  "keywords": [
-    "github",
-    "primer",
-    "css",
-    "stylelint-config",
-    "stylelint"
-  ]
+  }
 }

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,105 @@
+# Primer stylelint plugins
+This directory contains all of our custom stylelint plugins. These were
+intended for use with [Primer CSS] and GitHub projects, but you may find them
+useful elsewhere.
+
+## Usage
+If you're using or extending `stylelint-config-primer` already, then you're
+using all of these plugins by default. See [`index.js`](../index.js) for the
+config defaults.
+
+If you're _not_ using or extending `stylelint-config-primer`, you can still
+reference the plugins by referencing their module paths like so:
+
+```js
+// stylelint.config.js
+module.exports = {
+  plugins: [
+    'stylelint-config-primer/plugins/no-override',
+    'stylelint-config-primer/plugins/no-unused-vars'
+  ]
+}
+```
+
+## Plugins
+
+### `primer/no-override`
+This plugin helps prohibits "overriding" class selectors defined in [Primer
+CSS]. By default, it will only fail selectors that target utility classes:
+
+```scss
+// FAIL
+.mt-0 { /* literally anything */ }
+```
+
+You can further constrain overrides to exclude _any_ class selector in Primer
+by providing additional names in the `bundles` option:
+
+```js
+// stylelint.config.js
+module.exports = {
+  // ...
+  rules: {
+    'primer/no-override': [
+      true,
+      {
+        bundles: ['utilities', core', 'product', 'marketing']
+      }
+    ]
+  }
+}
+```
+
+### `primer/no-unused-vars`
+This plugin helps you find SCSS variables that _may_ not be used, and can be
+safely deleted. It works by scanning all of the SCSS files in your project and
+looking for anything that appears to be either a Sass variable declaration or
+reference:
+
+```scss
+    $name: value;
+/**      ↑
+ *  The colon is what makes this a declaration */
+
+/* Anything starting with a $ and followed by word chars or hyphens
+ * and _not_ followed by a colon is considered a reference: */
+
+    margin: $value;
+/**               ↑
+ *                Not a colon */
+    padding: $value 1px;
+/**                ↑
+ *                 Not a colon */
+
+@media screen and (max-width: $break-lg) {
+/**                                    ↑
+ *                                     Also not a colon */
+```
+
+Armed with a list of all the variable declarations and references, the linting
+rule walks all of the declarations in the file being linted, finds any that
+look like declarations (using the same pattern as the project-wide scan), and
+generates a warning for any that have zero references in the files it's
+scanned.
+
+Because there isn't any good way for a stylelint plugin to know all of the
+files being linted, it needs to be told where to find all of the declarations
+and references in its options:
+
+* `files` a single path, glob, or array of paths and globs, that tells the
+  plugin which files to scan relative to the current working directory. The
+  default is `['**/*.scss', '!node_modules']`, which tells [globby] to find all
+  the `.scss` files recursively and ignore the `node_modules` directory.
+
+* `variablePattern` is a regular expression that matches a single variable in
+  either a source file string or the `prop` of a postcss `decl` node. The
+  default matches Sass/SCSS variables: `/\$[-\w]/g`. Note that the `g`
+  ("global") flag is _required_ to match multiple variable references on a
+  single line.
+
+* `verbose` is a boolean that enables chatty `console.warn()` messages telling
+  you what the plugin found, which can aid in debugging more complicated
+  project layouts.
+
+[primer css]: https://primer.style/css
+[globby]: https://www.npmjs.com/package/globby

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,15 +1,23 @@
 # Primer stylelint plugins
-This directory contains all of our custom stylelint plugins. These were
-intended for use with [Primer CSS] and GitHub projects, but you may find them
-useful elsewhere.
+This directory contains all of our custom stylelint plugins, each
+of which provides a single stylelint rule.
+
+### Rules
+- [`primer/no-override`](#primerno-override)
+- [`primer/no-unused-vars`](#primerno-unused-vars)
+- [`primer/variables`](#primervariables)
+
+These were intended for use with [Primer CSS] and GitHub
+projects, but you may find them useful elsewhere.
 
 ## Usage
-If you're using or extending `stylelint-config-primer` already, then you're
-using all of these plugins by default. See [`index.js`](../index.js) for the
-config defaults.
+If you're using or extending `stylelint-config-primer` already,
+then you're using all of these plugins by default. See
+[`index.js`](../index.js) for the config defaults.
 
-If you're _not_ using or extending `stylelint-config-primer`, you can still
-reference the plugins by referencing their module paths like so:
+If you're _not_ using or extending `stylelint-config-primer`, you
+can still reference the plugins by referencing their module paths
+like so:
 
 ```js
 // stylelint.config.js
@@ -21,19 +29,19 @@ module.exports = {
 }
 ```
 
-## Plugins
-
-### `primer/no-override`
-This plugin helps prohibits "overriding" class selectors defined in [Primer
-CSS]. By default, it will only fail selectors that target utility classes:
+## `primer/no-override`
+This rule prohibits "overriding" class selectors defined in
+[Primer CSS]. By default, it will only fail selectors that target
+utility classes:
 
 ```scss
 // FAIL
 .mt-0 { /* literally anything */ }
 ```
 
-You can further constrain overrides to exclude _any_ class selector in Primer
-by providing additional names in the `bundles` option:
+You can further constrain overrides to exclude _any_ class
+selector in Primer by providing additional names in the `bundles`
+option:
 
 ```js
 // stylelint.config.js
@@ -50,11 +58,11 @@ module.exports = {
 }
 ```
 
-### `primer/no-unused-vars`
-This plugin helps you find SCSS variables that _may_ not be used, and can be
-safely deleted. It works by scanning all of the SCSS files in your project and
-looking for anything that appears to be either a Sass variable declaration or
-reference:
+## `primer/no-unused-vars`
+This rule helps you find SCSS variables that _may_ not be used,
+and can be safely deleted. It works by scanning all of the SCSS
+files in your project and looking for anything that appears to be
+either a Sass variable declaration or reference:
 
 ```scss
     $name: value;
@@ -76,30 +84,201 @@ reference:
  *                                     Also not a colon */
 ```
 
-Armed with a list of all the variable declarations and references, the linting
-rule walks all of the declarations in the file being linted, finds any that
-look like declarations (using the same pattern as the project-wide scan), and
-generates a warning for any that have zero references in the files it's
+Armed with a list of all the variable declarations and
+references, the linting rule walks all of the declarations in the
+file being linted, finds any that look like declarations (using
+the same pattern as the project-wide scan), and generates a
+warning for any that have zero references in the files it's
 scanned.
 
-Because there isn't any good way for a stylelint plugin to know all of the
-files being linted, it needs to be told where to find all of the declarations
-and references in its options:
+Because there isn't any good way for a stylelint plugin to know
+all of the files being linted, it needs to be told where to find
+all of the declarations and references in its options:
 
-* `files` a single path, glob, or array of paths and globs, that tells the
-  plugin which files to scan relative to the current working directory. The
-  default is `['**/*.scss', '!node_modules']`, which tells [globby] to find all
-  the `.scss` files recursively and ignore the `node_modules` directory.
+- `files` a single path, glob, or array of paths and globs, that
+  tells the plugin which files to scan relative to the current
+  working directory. The default is `['**/*.scss',
+  '!node_modules']`, which tells [globby] to find all the `.scss`
+  files recursively and ignore the `node_modules` directory.
 
-* `variablePattern` is a regular expression that matches a single variable in
-  either a source file string or the `prop` of a postcss `decl` node. The
-  default matches Sass/SCSS variables: `/\$[-\w]/g`. Note that the `g`
-  ("global") flag is _required_ to match multiple variable references on a
-  single line.
+- `variablePattern` is a regular expression that matches a single
+  variable in either a source file string or the `prop` of a
+  postcss `decl` node. The default matches Sass/SCSS variables:
+  `/\$[-\w]/g`. Note that the `g` ("global") flag is _required_
+  to match multiple variable references on a single line.
 
-* `verbose` is a boolean that enables chatty `console.warn()` messages telling
-  you what the plugin found, which can aid in debugging more complicated
-  project layouts.
+- `verbose` is a boolean that enables chatty `console.warn()`
+  messages telling you what the plugin found, which can aid in
+  debugging more complicated project layouts.
+
+## `primer/variables`
+This rule is a general-purpose linter for constraining values
+allowed in specific CSS properties, but comes with a default
+[rule set](#primer-variable-rules) tailored for big projects
+built on [Primer CSS]. Some examples:
+
+```scss
+body { color: black; }
+/**           ↑
+ *            FAIL: Use a variable. */
+
+body { color: $gray-900; }
+/**           ↑
+ *            FAIL: Use $text-gray-dark instead. */
+
+ul { margin: 0 0 $spacer-3; }
+/**          ↑
+ *           OK: "0" and "$spacer-*" are allowed values */
+
+ul { margin: 0 0 16px; }
+/**              ↑
+ *               FAIL: Use "$spacer-3" (auto-fixable!) */
+}
+```
+
+### Options
+- `rules` is an optional object providing one or more [variable
+  rules](#variable-rules) by name. Individual [Primer
+  rules](#primer-variable-rules) can be overridden or disabled:
+
+  ```js
+  rules: {
+    'primer/variables': [true, {
+      rules: {
+        // disable background-color checks
+        'background color': false,
+        // override text color (color) checks
+        'text color': {
+          props: ['fill', 'color'],
+          values: ['$text-*', '$fill-*', 'transparent', 'currentColor']
+        }
+      }
+    }]
+  }
+  ```
+
+- `verbose` is a boolean that enables chatty `console.warn()`
+  messages that can help you debug complicated variable rules.
+
+- `disableFix` is a boolean that can disable auto-fixing of this
+  rule when running `stylelint --fix` to auto-fix other rules.
+
+### Variable rules
+Each key/value pair in the `rules` option object defines a set of
+named constraints that apply to one or more CSS properties, and
+can provide auto-fix replacements for known exact matches. Each
+key of the `rules` object is the human-readable name of the rule.
+The value is another object with one or more of the following
+properties:
+
+- `props` is an array or string of [glob patterns] that match CSS
+  properties. For individual properties like `color`, a string
+  without any special glob characters is great. To match
+  directional properties, though, use the following pattern:
+
+  ```js
+  'border width': {
+    props: 'border{,-top,-right,-bottom,-left}-width',
+    // which expands to:
+    props: [
+      'border-width',
+      'border-top-width',
+      'border-right-width',
+      'border-bottom-width',
+      'border-left-width'
+    ]
+  }
+  ```
+
+- `values` is, similar to `props`, an array or string of [glob
+  patterns] that match _individual CSS values_ in a single
+  property. Property values are split on whitespace (respecing
+  parentheses, functions and arguments); if a property has more
+  than one value, each one is compared against the `values` list
+  to determine its validity. (The `!important` identifier is
+  _always_ valid.)
+
+  For example, if we fleshed out the `border width` rule defined
+  above with `values`:
+
+  ```js
+  'border width': {
+    props: 'border{,-top,-right,-bottom,-left}-width',
+    values: ['$border-*', '0']
+  }
+  ```
+
+  Then the following CSS checks out:
+
+  ```scss
+  .Box {
+    border-width: 0 0 $border-width;
+  /**             ↑ ↑ ↑
+   *              ↑ ↑ OK!
+   *              ↑ OK!
+   *              OK!                */
+  }
+  ```
+
+- `components` tells the rule that all of the properties matching
+  `props` resolve to a list of ordered properties with their
+  _own_, separately defined rules. This makes it possible for
+  compound CSS properties like `border`, `background`, or `font`
+  to "delegate" validation of each component of their value to
+  a rule with more specific constraints. For example, you could
+  succinctly enforce different types of border variables for most
+  of the CSS border properties with:
+
+  ```js
+  'border': {
+    props: 'border{,-top,-right,-bottom,-left}',
+    components: ['border-width', 'border-style', 'border-color']
+  },
+  'border width': {
+    props: 'border{,-top,-right,-bottom,-left}-width',
+    values: ['$border-width', '0']
+  },
+  'border style': {
+    props: 'border{,-top,-right,-bottom,-left}-style',
+    values: ['$border-style', 'none']
+  },
+  'border color': {
+    props: 'border{,-top,-right,-bottom,-left}-color',
+    values: ['$border-*', 'transparent']
+  }
+  ```
+
+- `replacements` is an object listing property values that can
+  safely be replaced via `stylelint --fix` with other variable or
+  static values, as in the Primer CSS `font-size` rule:
+
+  ```js
+  'font-size': {
+    props: 'font-size',
+    values: ['$h{0,1,2,3,4,5,6}-size', '$font-size-small'],
+    replacements: {
+      '40px': '$h0-size',
+      '32px': '$h1-size',
+      '24px': '$h2-size',
+      '20px': '$h3-size',
+      '16px': '$h4-size',
+      '14px': '$h5-size',
+      '12px': '$h6-size'
+    }
+  }
+  ```
+
+### Primer variable rules
+In general, the Primer CSS variable rules enforce two basic
+principles for custom CSS:
+
+- Use Primer variables whenever possible.
+- Use _functional_ variables (`$text-gray` vs. `$gray-700`)
+  whenever possible.
+
+See [`plugins/lib/variable-rules.js`](./lib/variable-rules.js)
+for the full set of rules.
 
 [primer css]: https://primer.style/css
 [globby]: https://www.npmjs.com/package/globby
+[glob patterns]: http://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm

--- a/plugins/lib/tokens.js
+++ b/plugins/lib/tokens.js
@@ -1,0 +1,50 @@
+module.exports = {splitTokens}
+
+/**
+ * In order to recognize "components" of compound properties like
+ * border and font, we have to know how to split up a CSS property
+ * value string into its constituent parts. However, just splitting on
+ * spaces isn't good enough, for instance:
+ *
+ * ```css
+ * border: ($spacer-2 - 1) solid lighten($gray-300, 4%);
+ * ```
+ *
+ * Math expressions, functions, and nested instances of each are
+ * treated as singular "tokens", so the above value would yield:
+ *
+ * 1. "($spacer-2 - 1)"
+ * 2. "solid"
+ * 3. "lighten($gray-300, 4%)"
+ */
+function splitTokens(value) {
+  const tokens = []
+  let token = ''
+  let parens = 0
+  for (let i = 0; i < value.length; i++) {
+    const chr = value.charAt(i)
+    if (chr === '(') {
+      token += chr
+      parens++
+    } else if (parens) {
+      token += chr
+      if (chr === ')') {
+        if (--parens === 0) {
+          tokens.push(token)
+          token = ''
+        }
+      }
+    } else if (chr === ' ') {
+      if (token) {
+        tokens.push(token)
+      }
+      token = ''
+    } else {
+      token += chr
+    }
+  }
+  if (token) {
+    tokens.push(token)
+  }
+  return tokens.map(token => token.replace(/,$/, ''))
+}

--- a/plugins/lib/variable-rules.js
+++ b/plugins/lib/variable-rules.js
@@ -1,0 +1,207 @@
+const matchAll = require('string.prototype.matchall')
+
+const SPACE_VALUES = ['$spacer-*', '-$spacer-*', '0', 'auto', 'inherit']
+const SPACE_FIXES = {
+  '4px': '$spacer-1',
+  // '5px': '$spacer-1',
+  '8px': '$spacer-2',
+  // '15px': '$spacer-3',
+  '16px': '$spacer-3'
+}
+const COLOR_VALUES = ['currentColor', 'inherit', 'none', 'transparent']
+
+module.exports = {
+  'background color': {
+    props: ['background-color'],
+    values: ['$bg-*', 'transparent', 'none'],
+    replacements: Object.assign(
+      {
+        // '#000': '$black',
+        // 'black': '$black',
+        '#fff': '$bg-white',
+        white: '$bg-white'
+      },
+      reverseAssignments(`
+      $bg-blue-light:     $blue-000 !default;
+      $bg-blue:           $blue-500 !default;
+      $bg-gray-dark:      $gray-900 !default;
+      $bg-gray-light:     $gray-000 !default;
+      $bg-gray:           $gray-100 !default;
+      $bg-green:          $green-500 !default;
+      $bg-green-light:    $green-100 !default;
+      $bg-orange:         $orange-700 !default;
+      $bg-purple:         $purple-500 !default;
+      $bg-purple-light:   $purple-000 !default;
+      $bg-pink:           $pink-500 !default;
+      $bg-red:            $red-500 !default;
+      $bg-red-light:      $red-100 !default;
+      $bg-white:          $white !default;
+      $bg-yellow:         $yellow-500 !default;
+      $bg-yellow-light:   $yellow-200 !default;
+      $bg-yellow-dark:    $yellow-700 !default;
+
+      $black-fade-15:      rgba($black, 0.15) !default;
+      $black-fade-30:      rgba($black, 0.3) !default;
+      $black-fade-50:      rgba($black, 0.5) !default;
+      $black-fade-70:      rgba($black, 0.7) !default;
+      $black-fade-85:      rgba($black, 0.85) !default;
+      $white-fade-15:      rgba($white, 0.15) !default;
+      $white-fade-30:      rgba($white, 0.3) !default;
+      $white-fade-50:      rgba($white, 0.5) !default;
+      $white-fade-70:      rgba($white, 0.7) !default;
+      $white-fade-85:      rgba($white, 0.85) !default;
+    `)
+    )
+  },
+  border: {
+    props: 'border{,-top,-right,-bottom,-left}',
+    values: ['$border', 'none', '0'],
+    components: ['border-width', 'border-style', 'border-color'],
+    replacements: {
+      '$border-width $border-style $border-color': '$border',
+      '$border-width $border-color $border-style': '$border'
+    }
+  },
+  'border color': {
+    props: 'border{,-top,-right,-bottom,-left}-color',
+    values: ['$border-*'].concat(COLOR_VALUES),
+    replacements: reverseAssignments(`
+      $border-black-fade:  $black-fade-15 !default;
+      $border-white-fade:  $white-fade-15 !default;
+      $border-blue:        $blue-500 !default;
+      $border-blue-light:  $blue-200 !default;
+      $border-green:       $green-400 !default;
+      $border-green-light: desaturate($green-300, 40%) !default;
+      $border-purple:      $purple !default;
+      $border-red:         $red !default;
+      $border-red-light:   desaturate($red-300, 60%) !default;
+      $border-yellow:      desaturate($yellow-300, 60%) !default;
+      $border-gray-dark:   $gray-300 !default;
+      $border-gray-darker: $gray-700 !default;
+      $border-gray-light:  lighten($gray-200, 3%) !default;
+      $border-gray:        $gray-200 !default;
+
+      $black-fade-15:      rgba($black, 0.15) !default;
+      $black-fade-30:      rgba($black, 0.3) !default;
+      $black-fade-50:      rgba($black, 0.5) !default;
+      $black-fade-70:      rgba($black, 0.7) !default;
+      $black-fade-85:      rgba($black, 0.85) !default;
+      $white-fade-15:      rgba($white, 0.15) !default;
+      $white-fade-30:      rgba($white, 0.3) !default;
+      $white-fade-50:      rgba($white, 0.5) !default;
+      $white-fade-70:      rgba($white, 0.7) !default;
+      $white-fade-85:      rgba($white, 0.85) !default;
+    `)
+  },
+  'border style': {
+    props: 'border{,-top,-right,-bottom,-left}-style',
+    values: ['$border-style', 'none'],
+    replacements: {solid: '$border-style'}
+  },
+  'border width': {
+    props: 'border{,-top,-right,-bottom,-left}-width',
+    values: ['$border-width*', '0', 'none'],
+    replacements: {'1px': '$border-width'}
+  },
+  'border radius': {
+    props: 'border{,-{top,bottom}-{left,right}}-radius',
+    values: ['$border-radius', '0', '100%'],
+    replacements: {'3px': '$border-radius'}
+  },
+  'box shadow': {
+    props: 'box-shadow',
+    values: ['$box-shadow*', '0'],
+    replacements: reverseAssignments(`
+      $box-shadow: 0 1px 1px rgba($black, 0.1) !default;
+      $box-shadow-medium: 0 1px 5px $black-fade-15 !default;
+      $box-shadow-large: 0 1px 15px $black-fade-15 !default;
+      $box-shadow-extra-large: 0 10px 50px rgba($black, 0.07) !default;
+    `)
+  },
+  'text color': {
+    props: 'color',
+    values: ['$text-*'].concat(COLOR_VALUES),
+    replacements: Object.assign(
+      {
+        '#fff': '$text-white',
+        white: '$text-white',
+        '#000': '$text-gray-dark',
+        black: '$text-gray-dark'
+      },
+      reverseAssignments(`
+      $text-blue:         $blue-500 !default;
+      $text-gray-dark:    $gray-900 !default;
+      $text-gray-light:   $gray-500 !default;
+      $text-gray:         $gray-600 !default;
+      $text-green:        $green-500 !default;
+      $text-orange:       $orange-900 !default;
+      $text-orange-light: $orange-600 !default;
+      $text-purple:       $purple !default;
+      $text-pink:         $pink-500 !default;
+      $text-red:          $red-600 !default;
+      $text-white:        $white !default;
+      $text-yellow:       $yellow-800 !default;
+    `)
+    )
+  },
+  margin: {
+    props: 'margin{,-top,-right,-bottom,-left}',
+    values: SPACE_VALUES,
+    replacements: SPACE_FIXES
+  },
+  padding: {
+    props: 'padding{,-top,-right,-bottom,-left}',
+    values: SPACE_VALUES,
+    replacements: SPACE_FIXES
+  },
+  'font-size': {
+    props: 'font-size',
+    values: ['$h{00,0,1,2,3,4,5,6}-size', '$h{00,0,1,2,3,4,5,6}-size-mobile', '$font-size-*', '1', '1em', 'inherit'],
+    replacements: reverseAssignments(`
+      // XXX should we include h*-size-mobile??
+      $h00-size: 48px !default;
+      $h0-size: 40px !default;
+      $h1-size: 32px !default;
+      $h2-size: 24px !default;
+      $h3-size: 20px !default;
+      $h4-size: 16px !default;
+      $h5-size: 14px !default;
+      $h6-size: 12px !default;
+      $font-size-small: 12px !default;
+    `)
+  },
+  'font-weight': {
+    props: 'font-weight',
+    values: ['$font-weight-*', 'inherit'],
+    replacements: Object.assign(
+      {
+        bold: '$font-weight-bold',
+        normal: '$font-weight-normal'
+      },
+      reverseAssignments(`
+      $font-weight-bold: 600 !default;
+      $font-weight-semibold: 500 !default;
+      $font-weight-normal: 400 !default;
+      $font-weight-light: 300 !default;
+    `)
+    )
+  },
+  'line-height': {
+    props: 'line-height',
+    values: ['$lh-*', '0', '1', '1em', 'inherit'],
+    replacements: reverseAssignments(`
+      $lh-condensed-ultra: 1 !default;
+      $lh-condensed: 1.25 !default;
+      $lh-default: 1.5 !default;
+    `)
+  }
+}
+
+function reverseAssignments(css) {
+  const map = {}
+  // eslint-disable-next-line no-unused-vars
+  for (const [_, left, right] of matchAll(css, /(\$[-\w]+):\s+([^!]+) !default;/g)) {
+    map[right] = left
+  }
+  return map
+}

--- a/plugins/no-unused-vars.js
+++ b/plugins/no-unused-vars.js
@@ -1,0 +1,96 @@
+const TapMap = require('tap-map')
+const globby = require('globby')
+const matchAll = require('string.prototype.matchall')
+const stylelint = require('stylelint')
+const {readFileSync} = require('fs')
+
+const ruleName = 'primer/no-unused-vars'
+
+const cwd = process.cwd()
+const COLON = ':'
+const SCSS_VARIABLE_PATTERN = /(\$[-\w]+)/g
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+  rejected: name => `The variable "${name}" is not referenced.`
+})
+
+const cache = new TapMap()
+
+module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
+  if (!enabled) {
+    return noop
+  }
+
+  const {files = ['**/*.scss', '!node_modules'], variablePattern = SCSS_VARIABLE_PATTERN, verbose = false} = options
+  // eslint-disable-next-line no-console
+  const log = verbose ? (...args) => console.warn(...args) : noop
+  const cacheOptions = {files, variablePattern, cwd}
+  const {refs} = getCachedVariables(cacheOptions, log)
+
+  return (root, result) => {
+    root.walkDecls(decl => {
+      for (const [name] of matchAll(decl.prop, variablePattern)) {
+        if (!refs.has(name)) {
+          stylelint.utils.report({
+            message: messages.rejected(name),
+            node: decl,
+            result,
+            ruleName
+          })
+        } else {
+          const path = stripCwd(decl.source.input.file)
+          log(`${name} declared in ${path} ref'd in ${pluralize(refs.get(name).size, 'file')}`)
+        }
+      }
+    })
+  }
+})
+
+function getCachedVariables(options, log) {
+  const key = JSON.stringify(options)
+  return cache.tap(key, () => {
+    const {files, variablePattern} = options
+    const decs = new TapMap()
+    const refs = new TapMap()
+
+    log(`Looking for variables in ${files} ...`)
+    for (const file of globby.sync(files)) {
+      const css = readFileSync(file, 'utf8')
+      for (const match of matchAll(css, variablePattern)) {
+        const after = css.substr(match.index + match[0].length)
+        const name = match[0]
+        if (after.startsWith(COLON)) {
+          decs.tap(name, set).add(file)
+        } else {
+          refs.tap(name, set).add(file)
+        }
+      }
+    }
+    log(`Found ${decs.size} declarations, ${pluralize(refs.size, 'reference')}.`)
+
+    for (const [name, files] of decs.entries()) {
+      const fileRefs = refs.get(name)
+      if (fileRefs) {
+        log(`variable "${name}" declared in ${pluralize(files.size, 'file')}, ref'd in ${fileRefs.size}`)
+      } else {
+        log(`[!] variable "${name}" declared in ${Array.from(files)[0]} is not referenced`)
+      }
+    }
+
+    return {decs, refs}
+  })
+}
+
+function noop() {}
+
+function set() {
+  return new Set()
+}
+
+function stripCwd(path) {
+  return path.startsWith(cwd) ? path.substr(cwd.length + 1) : path
+}
+
+function pluralize(num, str, plural = `${str}s`) {
+  return num === 1 ? `${num} ${str}` : `${num} ${plural}`
+}

--- a/plugins/variables.js
+++ b/plugins/variables.js
@@ -1,0 +1,167 @@
+const anymatch = require('anymatch')
+const stylelint = require('stylelint')
+const TapMap = require('tap-map')
+const braces = require('braces')
+const {splitTokens} = require('./lib/tokens')
+
+const ruleName = 'primer/variables'
+const IMPORTANT = '!important'
+
+const DEFAULT_RULES = require('./lib/variable-rules')
+
+module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}, context = {}) => {
+  if (enabled === false) {
+    return noop
+  }
+
+  // The stylelint docs suggest respecting a "disableFix" rule option that
+  // overrides the "global" context.fix (--fix) linting option.
+  const fixEnabled = context.fix && !options.disableFix
+  const {verbose = false} = options
+
+  /* Rules are keyed on their name so that it's easy to override or disable
+   * them while still "inheriting" the defaults:
+   *
+   * ```js
+   * 'primer/variables': [true, {
+   *   rules: {
+   *     'background color': false,
+   *     'text color': {
+   *       props: ['fill', 'color'],
+   *       values: ['$text-*', '$fill-*', 'transparent', 'currentColor']
+   *     }
+   *   }
+   * }
+   * ```
+   */
+  const rules = Object.assign({}, DEFAULT_RULES, options.rules)
+  const cache = new TapMap()
+  const tokenReplacementsByProperty = new Map()
+  const entries = Object.entries(rules)
+    .map(([name, rule]) => {
+      if (!rule) {
+        return false
+      } else if (!rule.props && verbose) {
+        // eslint-disable-next-line no-console
+        console.warn(`[${ruleName}] rule "${name}" has no .props; the name will be used.`)
+        rule.props = name
+      }
+      return Object.assign(
+        {
+          name,
+          match: anymatch(rule.props),
+          replacements: {}
+        },
+        rule,
+        {
+          testValue: getRuleValueTester(rule)
+        }
+      )
+    })
+    .filter(Boolean)
+
+  for (const entry of entries) {
+    const props = arrayify(entry.props).flatMap(braces.expand)
+    for (const prop of props) {
+      for (const [token, replacement] of Object.entries(entry.replacements)) {
+        tokenReplacementsByProperty.set(`${prop}:${token}`, replacement)
+        if (verbose) {
+          // eslint-disable-next-line no-console
+          console.warn(`replace: {${prop}: ${token}} -> "${replacement}"`)
+        }
+      }
+    }
+  }
+
+  return (root, result) => {
+    const messages = stylelint.utils.ruleMessages(ruleName, {
+      rejected: message => message
+    })
+
+    root.walkDecls(decl => check(decl))
+
+    function check(decl, prop = decl.prop, value = decl.value) {
+      let replacementKey = `${prop}:${value}`
+      let message
+      if (prop === decl.prop && tokenReplacementsByProperty.has(replacementKey)) {
+        const replacement = tokenReplacementsByProperty.get(replacementKey)
+        if (fixEnabled) {
+          decl.value = replacement
+        } else {
+          message = `Please use "${replacement}" instead of "${value}"`
+        }
+      }
+
+      const rule = cache.tap(prop, () => entries.find(entry => entry.match(prop)))
+      if (rule) {
+        const {name} = rule
+        const tokens = splitTokens(value)
+        let fixed = false
+        if (tokens.length > 1 && Array.isArray(rule.components)) {
+          for (const [index, comp] of Object.entries(rule.components)) {
+            const token = tokens[index]
+            const fixedToken = check(decl, comp, token)
+            if (fixEnabled && fixedToken) {
+              tokens[index] = fixedToken
+              fixed = true
+            }
+          }
+        } else {
+          for (const [index, token] of Object.entries(tokens)) {
+            replacementKey = `${prop}:${token}`
+            if (fixEnabled && rule.replacements.hasOwnProperty(token)) {
+              tokens[index] = rule.replacements[token]
+              fixed = true
+            } else if (tokenReplacementsByProperty.has(replacementKey)) {
+              const replacement = tokenReplacementsByProperty.get(replacementKey)
+              if (verbose) {
+                // eslint-disable-next-line no-console
+                console.warn(`found exact replacement for {${prop}: ${token}}: "${replacement}"`)
+              }
+              if (fixEnabled) {
+                tokens[index] = replacement
+                fixed = true
+              } else {
+                message = `Please use "${replacement}" instead of "${token}"`
+                break
+              }
+            } else if (!rule.testValue(token)) {
+              message = `Please use a ${name} variable instead of "${value}"`
+              break
+            }
+          }
+        }
+
+        if (fixed) {
+          if (prop === decl.prop) {
+            decl.value = tokens.join(' ')
+          } else {
+            return tokens.join(' ')
+          }
+        } else if (message) {
+          stylelint.utils.report({
+            message: messages.rejected(`${message}.`),
+            node: decl,
+            result,
+            ruleName
+          })
+        }
+      }
+    }
+  }
+})
+
+// export the default rules object so that it can be built on
+Object.assign(module.exports, {DEFAULT_RULES})
+
+function getRuleValueTester(rule) {
+  const {values = []} = rule
+  const match = anymatch(values)
+  return v => v === IMPORTANT || match(v)
+}
+
+function noop() {}
+
+function arrayify(value) {
+  return Array.isArray(value) ? value : [value]
+}


### PR DESCRIPTION
### :rocket: Features
- [x] The new `primer/no-unused-vars` rule helps catch unused Sass variables in your project #46 
- [x] The new `primer/variables` rule helps enforce the use of specific Primer SCSS variables in a variety of known CSS properties, and can fix common problems automatically! #28 

### :memo: Documentation
- [x] All plugins (rules) now have public docs in [plugins/README.md](https://github.com/primer/stylelint-config-primer/blob/release-8.2.0/plugins/README.md) (as of #46)

### :house: Internal
- [x] Resolve a security vulnerability with `npm audit fix`