### PR TITLE
Enable variables plugin during test

### DIFF
--- a/__tests__/variables.js
+++ b/__tests__/variables.js
@@ -27,7 +27,7 @@ describe(ruleName, () => {
     return stylelint
       .lint({
         code: `.x { display: block; }`,
-        config: configWithOptions(false)
+        config: configWithOptions(true)
       })
       .then(data => {
         expect(data).not.toHaveErrored()


### PR DESCRIPTION
Minor fix; enables the `variables` plugin during the "doesn't reject properties we don't care about" test.