### PR TITLE
Get variable aliases from @primer/css/dist/variables.json

### DIFF
--- a/__tests__/borders.js
+++ b/__tests__/borders.js
@@ -65,7 +65,10 @@ describe(ruleName, () => {
       return stylelint
         .lint({
           code: dedent`
-            .x { border: 1px solid $gray-300; }
+            .a { border: 1px solid $gray-300; }
+            .b { border: 1px solid $gray-200; }
+            .c { border: solid 1px $border-gray; }
+            .d { border: 1px $border-color solid; }
           `,
           config: configWithOptions(true),
           fix: true
@@ -74,7 +77,10 @@ describe(ruleName, () => {
           expect(data).not.toHaveErrored()
           expect(data).toHaveWarningsLength(0)
           expect(data.output).toEqual(dedent`
-            .x { border: $border-width $border-style $border-gray-dark; }
+            .a { border: $border-width $border-style $border-gray-dark; }
+            .b { border: $border; }
+            .c { border: $border; }
+            .d { border: $border; }
           `)
         })
     })

--- a/__tests__/borders.js
+++ b/__tests__/borders.js
@@ -60,6 +60,24 @@ describe(ruleName, () => {
       })
   })
 
+  it('allows $border shorthand in border{,-top,-right,-bottom,-left}', () => {
+    return stylelint
+      .lint({
+        code: dedent`
+          .a { border: $border; }
+          .b { border-top: $border; }
+          .c { border-right: $border; }
+          .d { border-bottom: $border; }
+          .e { border-left: $border; }
+        `,
+        config: configWithOptions(true)
+      })
+      .then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data).toHaveWarningsLength(0)
+      })
+  })
+
   describe('autofix', () => {
     it('fixes border variables', () => {
       return stylelint

--- a/__tests__/colors.js
+++ b/__tests__/colors.js
@@ -3,7 +3,7 @@ const stylelint = require('stylelint')
 const pluginPath = require.resolve('../plugins/colors')
 
 const ruleName = 'primer/colors'
-const configWithOptions = args => ({
+const configWithOptions = (...args) => ({
   plugins: [pluginPath],
   rules: {
     [ruleName]: args
@@ -141,6 +141,22 @@ describe(ruleName, () => {
         expect(data).toHaveErrored()
         expect(data).toHaveWarningsLength(1)
         expect(data).toHaveWarnings([`Please use a text color variable instead of "#f00". (${ruleName})`])
+      })
+  })
+
+  it('can override via options.rules', () => {
+    return stylelint
+      .lint({
+        code: `.x { color: #f00; }`,
+        config: configWithOptions(true, {
+          rules: {
+            'text color': false
+          }
+        })
+      })
+      .then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data).toHaveWarningsLength(0)
       })
   })
 })

--- a/__tests__/typography.js
+++ b/__tests__/typography.js
@@ -36,7 +36,6 @@ describe(ruleName, () => {
           code: dedent`
             .h1 { font-size: $h1-size; }
             .h2 { font-size: $h2-size; }
-            .h3-mobile { font-size: $h3-size-mobile; }
             small { font-size: $font-size-small; }
           `,
           config: configWithOptions(true)

--- a/package-lock.json
+++ b/package-lock.json
@@ -471,10 +471,22 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
     "@primer/css": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@primer/css/-/css-12.2.0.tgz",
-      "integrity": "sha512-RDavaudOWWta5X11p/q7+nSS+5p+FHCbKWXkHECm1THQ+l1bRk5FUr9Csy78lbqbknqnlF1Lw9qePAG+S4+WgQ==",
-      "dev": true
+      "version": "0.0.0-81c7695",
+      "resolved": "https://registry.npmjs.org/@primer/css/-/css-0.0.0-81c7695.tgz",
+      "integrity": "sha512-EMNe/M3MF3J272N3lasf+QjG3jgVlJQuVSAJydl8HnBs8pptDCJmoVwS5bvwrUug4JBhGKu2k6mgOKIUVEHQHA==",
+      "dev": true,
+      "requires": {
+        "@primer/octicons": "^9.1.1"
+      }
+    },
+    "@primer/octicons": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-9.2.0.tgz",
+      "integrity": "sha512-3vv7bBqVUHhU7ChpmQhmzz3WmHEKKSk9z/xEK5KnU8Egh96RoqKIim07geRj825ISa+IWj9cPdOA1ShqW5k3Yw==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1"
+      }
     },
     "@types/babel__core": {
       "version": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@primer/css": "*"
   },
   "devDependencies": {
-    "@primer/css": "^12.2.0",
+    "@primer/css": "0.0.0-81c7695",
     "dedent": "0.7.0",
     "eslint": "4.19.1",
     "eslint-plugin-github": "1.10.0",

--- a/plugins/borders.js
+++ b/plugins/borders.js
@@ -1,4 +1,4 @@
-const {createVariableRule, reverseAssignments} = require('./lib/variable-rules')
+const {createVariableRule} = require('./lib/variable-rules')
 
 module.exports = createVariableRule('primer/borders', {
   border: {
@@ -18,51 +18,21 @@ module.exports = createVariableRule('primer/borders', {
   'border color': {
     expects: 'a border color variable',
     props: 'border{,-top,-right,-bottom,-left}-color',
-    values: ['$border-*', 'transparent', 'currentColor'],
-    replacements: reverseAssignments(`
-      $border-black-fade:  $black-fade-15 !default;
-      $border-white-fade:  $white-fade-15 !default;
-      $border-blue:        $blue-500 !default;
-      $border-blue-light:  $blue-200 !default;
-      $border-green:       $green-400 !default;
-      $border-green-light: desaturate($green-300, 40%) !default;
-      $border-purple:      $purple !default;
-      $border-red:         $red !default;
-      $border-red-light:   desaturate($red-300, 60%) !default;
-      $border-yellow:      desaturate($yellow-300, 60%) !default;
-      $border-gray-dark:   $gray-300 !default;
-      $border-gray-darker: $gray-700 !default;
-      $border-gray-light:  lighten($gray-200, 3%) !default;
-      $border-gray:        $gray-200 !default;
-
-      $black-fade-15:      rgba($black, 0.15) !default;
-      $black-fade-30:      rgba($black, 0.3) !default;
-      $black-fade-50:      rgba($black, 0.5) !default;
-      $black-fade-70:      rgba($black, 0.7) !default;
-      $black-fade-85:      rgba($black, 0.85) !default;
-      $white-fade-15:      rgba($white, 0.15) !default;
-      $white-fade-30:      rgba($white, 0.3) !default;
-      $white-fade-50:      rgba($white, 0.5) !default;
-      $white-fade-70:      rgba($white, 0.7) !default;
-      $white-fade-85:      rgba($white, 0.85) !default;
-    `)
+    values: ['$border-*', 'transparent', 'currentColor']
   },
   'border style': {
     expects: 'a border style variable',
     props: 'border{,-top,-right,-bottom,-left}-style',
-    values: ['$border-style', 'none'],
-    replacements: {solid: '$border-style'}
+    values: ['$border-style', 'none']
   },
   'border width': {
     expects: 'a border width variable',
     props: 'border{,-top,-right,-bottom,-left}-width',
-    values: ['$border-width*', '0', 'none'],
-    replacements: {'1px': '$border-width'}
+    values: ['$border-width*', '0', 'none']
   },
   'border radius': {
     expects: 'a border radius variable',
     props: 'border{,-{top,bottom}-{left,right}}-radius',
-    values: ['$border-radius', '0', '50%', '100%'],
-    replacements: {'3px': '$border-radius'}
+    values: ['$border-radius', '0', '50%', '100%']
   }
 })

--- a/plugins/borders.js
+++ b/plugins/borders.js
@@ -7,6 +7,13 @@ module.exports = createVariableRule('primer/borders', {
     values: ['$border', 'none', '0'],
     components: ['border-width', 'border-style', 'border-color'],
     replacements: {
+      // because shorthand border properties ¯\_(ツ)_/¯
+      '$border-width $border-style $border-gray': '$border',
+      '$border-width $border-gray $border-style': '$border',
+      '$border-style $border-width $border-gray': '$border',
+      '$border-style $border-gray $border-width': '$border',
+      '$border-gray $border-width $border-style': '$border',
+      '$border-gray $border-style $border-width': '$border',
       '$border-width $border-style $border-color': '$border',
       '$border-width $border-color $border-style': '$border',
       '$border-style $border-width $border-color': '$border',
@@ -18,7 +25,10 @@ module.exports = createVariableRule('primer/borders', {
   'border color': {
     expects: 'a border color variable',
     props: 'border{,-top,-right,-bottom,-left}-color',
-    values: ['$border-*', 'transparent', 'currentColor']
+    values: ['$border-*', 'transparent', 'currentColor'],
+    replacements: {
+      '$border-gray': '$border-color'
+    }
   },
   'border style': {
     expects: 'a border style variable',

--- a/plugins/borders.js
+++ b/plugins/borders.js
@@ -38,7 +38,7 @@ module.exports = createVariableRule('primer/borders', {
   'border width': {
     expects: 'a border width variable',
     props: 'border{,-top,-right,-bottom,-left}-width',
-    values: ['$border-width*', '0', 'none']
+    values: ['$border-width*', '0']
   },
   'border radius': {
     expects: 'a border radius variable',

--- a/plugins/box-shadow.js
+++ b/plugins/box-shadow.js
@@ -4,12 +4,6 @@ module.exports = createVariableRule('primer/box-shadow', {
   'box shadow': {
     expects: 'a box-shadow variable',
     props: 'box-shadow',
-    values: ['$box-shadow*', 'none'],
-    replacements: {
-      '0 1px 1px rgba($black, 0.1)': '$box-shadow',
-      '0 1px 5px $black-fade-15': '$box-shadow-medium',
-      '0 1px 15px $black-fade-15': '$box-shadow-large',
-      '0 10px 50px rgba($black, 0.07)': '$box-shadow-extra-large'
-    }
+    values: ['$box-shadow*', 'none']
   }
 })

--- a/plugins/colors.js
+++ b/plugins/colors.js
@@ -1,74 +1,20 @@
-const {createVariableRule, reverseAssignments} = require('./lib/variable-rules')
+const {createVariableRule} = require('./lib/variable-rules')
 
 module.exports = createVariableRule('primer/colors', {
   'background color': {
     expects: 'a background color variable',
     props: ['background{,-color}'],
-    values: ['$bg-*', 'transparent', 'none'],
-    replacements: Object.assign(
-      {
-        // '#000': '$black',
-        // 'black': '$black',
-        '#fff': '$bg-white',
-        white: '$bg-white'
-      },
-      reverseAssignments(`
-        $bg-blue-light:     $blue-000 !default;
-        $bg-blue:           $blue-500 !default;
-        $bg-gray-dark:      $gray-900 !default;
-        $bg-gray-light:     $gray-000 !default;
-        $bg-gray:           $gray-100 !default;
-        $bg-green:          $green-500 !default;
-        $bg-green-light:    $green-100 !default;
-        $bg-orange:         $orange-700 !default;
-        $bg-purple:         $purple-500 !default;
-        $bg-purple-light:   $purple-000 !default;
-        $bg-pink:           $pink-500 !default;
-        $bg-red:            $red-500 !default;
-        $bg-red-light:      $red-100 !default;
-        $bg-white:          $white !default;
-        $bg-yellow:         $yellow-500 !default;
-        $bg-yellow-light:   $yellow-200 !default;
-        $bg-yellow-dark:    $yellow-700 !default;
-
-        $black-fade-15:      rgba($black, 0.15) !default;
-        $black-fade-30:      rgba($black, 0.3) !default;
-        $black-fade-50:      rgba($black, 0.5) !default;
-        $black-fade-70:      rgba($black, 0.7) !default;
-        $black-fade-85:      rgba($black, 0.85) !default;
-        $white-fade-15:      rgba($white, 0.15) !default;
-        $white-fade-30:      rgba($white, 0.3) !default;
-        $white-fade-50:      rgba($white, 0.5) !default;
-        $white-fade-70:      rgba($white, 0.7) !default;
-        $white-fade-85:      rgba($white, 0.85) !default;
-      `)
-    )
+    values: ['$bg-*', 'transparent', 'none']
   },
   'text color': {
     expects: 'a text color variable',
     props: 'color',
     values: ['$text-*'],
-    replacements: Object.assign(
-      {
-        '#fff': '$text-white',
-        white: '$text-white',
-        '#000': '$text-gray-dark',
-        black: '$text-gray-dark'
-      },
-      reverseAssignments(`
-        $text-blue:         $blue-500 !default;
-        $text-gray-dark:    $gray-900 !default;
-        $text-gray-light:   $gray-500 !default;
-        $text-gray:         $gray-600 !default;
-        $text-green:        $green-500 !default;
-        $text-orange:       $orange-900 !default;
-        $text-orange-light: $orange-600 !default;
-        $text-purple:       $purple !default;
-        $text-pink:         $pink-500 !default;
-        $text-red:          $red-600 !default;
-        $text-white:        $white !default;
-        $text-yellow:       $yellow-800 !default;
-      `)
-    )
+    replacements: {
+      '#fff': '$text-white',
+      white: '$text-white',
+      '#000': '$text-gray-dark',
+      black: '$black'
+    }
   }
 })

--- a/plugins/lib/decl-validator.js
+++ b/plugins/lib/decl-validator.js
@@ -81,7 +81,10 @@ module.exports = function declarationValidator(rules, options = {}) {
           replacement: undefined
         }
       } else if (replacements && replacements.hasOwnProperty(value)) {
-        const replacement = replacements[value]
+        let replacement = value
+        do {
+          replacement = replacements[replacement]
+        } while (replacements[replacement])
         return {
           valid: false,
           errors: [{expects, prop, value, replacement}],
@@ -181,7 +184,9 @@ module.exports = function declarationValidator(rules, options = {}) {
 
       // if a compound replacement exists, suggest *that* instead
       if (replacement && replacements && replacements.hasOwnProperty(replacement)) {
-        replacement = replacements[replacement]
+        do {
+          replacement = replacements[replacement]
+        } while (replacements[replacement])
         return {
           valid: false,
           errors: [{expects, prop, value: compoundValue, replacement}],

--- a/plugins/lib/decl-validator.js
+++ b/plugins/lib/decl-validator.js
@@ -141,10 +141,15 @@ module.exports = function declarationValidator(rules, options = {}) {
     }
   }
 
-  function componentValidator({expects, components, replacements = {}}) {
+  function componentValidator({expects, components, values, replacements = {}}) {
+    const matchesCompoundValue = anymatch(values)
     return decl => {
       const {prop, value: compoundValue} = decl
       const parsed = valueParser(compoundValue)
+      if (parsed.nodes.length === 1 && matchesCompoundValue(compoundValue)) {
+          return {valid: true, errors: []}
+      }
+
       const errors = []
 
       let fixable = false

--- a/plugins/lib/decl-validator.js
+++ b/plugins/lib/decl-validator.js
@@ -147,7 +147,7 @@ module.exports = function declarationValidator(rules, options = {}) {
       const {prop, value: compoundValue} = decl
       const parsed = valueParser(compoundValue)
       if (parsed.nodes.length === 1 && matchesCompoundValue(compoundValue)) {
-          return {valid: true, errors: []}
+        return {valid: true, errors: []}
       }
 
       const errors = []

--- a/plugins/lib/decl-validator.js
+++ b/plugins/lib/decl-validator.js
@@ -15,21 +15,22 @@ module.exports = function declarationValidator(rules, options = {}) {
     }
   }
 
-  const validators = Object.entries(rules).map(([key, rule]) => {
-    if (rule === false) {
-      return false
-    }
-    const {name = key, props = name, expects = `a ${name} value`} = rule
-    const replacements = Object.assign({}, rule.replacements, getVariableReplacements(rule.values))
-    // console.warn(`replacements for "${key}": ${JSON.stringify(replacements)}`)
-    Object.assign(rule, {name, props, expects, replacements})
-    return {
-      rule,
-      matchesProp: anymatch(props),
-      validate: Array.isArray(rule.components) ? componentValidator(rule) : valueValidator(rule)
-    }
-  })
-  .filter(Boolean)
+  const validators = Object.entries(rules)
+    .map(([key, rule]) => {
+      if (rule === false) {
+        return false
+      }
+      const {name = key, props = name, expects = `a ${name} value`} = rule
+      const replacements = Object.assign({}, rule.replacements, getVariableReplacements(rule.values))
+      // console.warn(`replacements for "${key}": ${JSON.stringify(replacements)}`)
+      Object.assign(rule, {name, props, expects, replacements})
+      return {
+        rule,
+        matchesProp: anymatch(props),
+        validate: Array.isArray(rule.components) ? componentValidator(rule) : valueValidator(rule)
+      }
+    })
+    .filter(Boolean)
 
   const validatorsByProp = new TapMap()
   const validatorsByReplacementValue = new Map()

--- a/plugins/lib/decl-validator.js
+++ b/plugins/lib/decl-validator.js
@@ -16,6 +16,9 @@ module.exports = function declarationValidator(rules, options = {}) {
   }
 
   const validators = Object.entries(rules).map(([key, rule]) => {
+    if (rule === false) {
+      return false
+    }
     const {name = key, props = name, expects = `a ${name} value`} = rule
     const replacements = Object.assign({}, rule.replacements, getVariableReplacements(rule.values))
     // console.warn(`replacements for "${key}": ${JSON.stringify(replacements)}`)
@@ -26,6 +29,7 @@ module.exports = function declarationValidator(rules, options = {}) {
       validate: Array.isArray(rule.components) ? componentValidator(rule) : valueValidator(rule)
     }
   })
+  .filter(Boolean)
 
   const validatorsByProp = new TapMap()
   const validatorsByReplacementValue = new Map()

--- a/plugins/lib/variable-rules.js
+++ b/plugins/lib/variable-rules.js
@@ -14,12 +14,13 @@ module.exports = {
 
 function createVariableRule(ruleName, rules) {
   const variables = require('@primer/css/dist/variables.json')
-  const validate = declarationValidator(rules, {variables})
 
   return stylelint.createPlugin(ruleName, (enabled, options = {}, context) => {
     if (enabled === false) {
       return noop
     }
+
+    const validate = declarationValidator(Object.assign(rules, options.rules), {variables})
 
     const messages = stylelint.utils.ruleMessages(ruleName, {
       rejected: message => `${message}.`

--- a/plugins/lib/variable-rules.js
+++ b/plugins/lib/variable-rules.js
@@ -15,12 +15,13 @@ module.exports = {
 }
 
 function createVariableRule(ruleName, rules) {
+  const variables = require('@primer/css/dist/variables.json')
+  const validate = declarationValidator(rules, {variables})
+
   return stylelint.createPlugin(ruleName, (enabled, options = {}, context) => {
     if (enabled === false) {
       return noop
     }
-
-    const validate = declarationValidator(rules, options)
 
     const messages = stylelint.utils.ruleMessages(ruleName, {
       rejected: message => `${message}.`

--- a/plugins/lib/variable-rules.js
+++ b/plugins/lib/variable-rules.js
@@ -13,7 +13,12 @@ module.exports = {
 }
 
 function createVariableRule(ruleName, rules) {
-  const variables = require('@primer/css/dist/variables.json')
+  let variables = {}
+  try {
+    variables = require('@primer/css/dist/variables.json')
+  } catch (error) {
+    console.warn(`Unable to get variables.json from @primer/css. Replacements will need to be specified manually.`)
+  }
 
   return stylelint.createPlugin(ruleName, (enabled, options = {}, context) => {
     if (enabled === false) {

--- a/plugins/lib/variable-rules.js
+++ b/plugins/lib/variable-rules.js
@@ -17,6 +17,7 @@ function createVariableRule(ruleName, rules) {
   try {
     variables = require('@primer/css/dist/variables.json')
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.warn(`Unable to get variables.json from @primer/css. Replacements will need to be specified manually.`)
   }
 

--- a/plugins/lib/variable-rules.js
+++ b/plugins/lib/variable-rules.js
@@ -1,4 +1,3 @@
-const matchAll = require('string.prototype.matchall')
 const stylelint = require('stylelint')
 const declarationValidator = require('./decl-validator')
 
@@ -8,7 +7,6 @@ const CSS_CORNERS = ['top-right', 'bottom-right', 'bottom-left', 'top-left']
 
 module.exports = {
   createVariableRule,
-  reverseAssignments,
   CSS_DIRECTIONS,
   CSS_CORNERS,
   CSS_IMPORTANT
@@ -62,12 +60,3 @@ function createVariableRule(ruleName, rules) {
 }
 
 function noop() {}
-
-function reverseAssignments(css) {
-  const map = {}
-  // eslint-disable-next-line no-unused-vars
-  for (const [_, left, right] of matchAll(css, /(\$[-\w]+):\s+([^!]+) !default;/g)) {
-    map[right] = left
-  }
-  return map
-}

--- a/plugins/spacing.js
+++ b/plugins/spacing.js
@@ -1,26 +1,16 @@
-const {createVariableRule, reverseAssignments} = require('./lib/variable-rules')
+const {createVariableRule} = require('./lib/variable-rules')
 
 const SPACE_VALUES = ['$spacer-*', '-$spacer-*', '0', 'auto', 'inherit']
-const SPACE_FIXES = reverseAssignments(`
-  $spacer-1: 4px !default;
-  $spacer-2: 8px !default;
-  $spacer-3: 16px !default;
-  $spacer-4: 24px !default;
-  $spacer-5: 32px !default;
-  $spacer-6: 40px !default;
-`)
 
 module.exports = createVariableRule('primer/spacing', {
   margin: {
     expects: 'a $spacer-* variable',
     props: 'margin{,-top,-right,-bottom,-left}',
-    values: SPACE_VALUES,
-    replacements: SPACE_FIXES
+    values: SPACE_VALUES
   },
   padding: {
     expects: 'a $spacer-* variable',
     props: 'padding{,-top,-right,-bottom,-left}',
-    values: SPACE_VALUES,
-    replacements: SPACE_FIXES
+    values: SPACE_VALUES
   }
 })

--- a/plugins/typography.js
+++ b/plugins/typography.js
@@ -1,44 +1,20 @@
-const {createVariableRule, reverseAssignments} = require('./lib/variable-rules')
+const {createVariableRule} = require('./lib/variable-rules')
 
 module.exports = createVariableRule('primer/typography', {
   'font-size': {
     expects: 'a font-size variable',
-    values: ['$h{00,0,1,2,3,4,5,6}-size', '$h{00,0,1,2,3,4,5,6}-size-mobile', '$font-size-*', '1', '1em', 'inherit'],
-    replacements: reverseAssignments(`
-      // XXX should we include h*-size-mobile??
-      $h00-size: 48px !default;
-      $h0-size: 40px !default;
-      $h1-size: 32px !default;
-      $h2-size: 24px !default;
-      $h3-size: 20px !default;
-      $h4-size: 16px !default;
-      $h5-size: 14px !default;
-      $h6-size: 12px !default;
-    `)
+    values: ['$h{00,0,1,2,3,4,5,6}-size', '$h{00,0,1,2,3,4,5,6}-size-mobile', '$font-size-*', '1', '1em', 'inherit']
   },
   'font-weight': {
     props: 'font-weight',
     values: ['$font-weight-*', 'inherit'],
-    replacements: Object.assign(
-      {
-        bold: '$font-weight-bold',
-        normal: '$font-weight-normal'
-      },
-      reverseAssignments(`
-        $font-weight-bold: 600 !default;
-        $font-weight-semibold: 500 !default;
-        $font-weight-normal: 400 !default;
-        $font-weight-light: 300 !default;
-      `)
-    )
+    replacements: {
+      bold: '$font-weight-bold',
+      normal: '$font-weight-normal'
+    }
   },
   'line-height': {
     props: 'line-height',
-    values: ['$lh-*', '0', '1', '1em', 'inherit'],
-    replacements: reverseAssignments(`
-      $lh-condensed-ultra: 1 !default;
-      $lh-condensed: 1.25 !default;
-      $lh-default: 1.5 !default;
-    `)
+    values: ['$lh-*', '0', '1', '1em', 'inherit']
   }
 })

--- a/plugins/typography.js
+++ b/plugins/typography.js
@@ -3,7 +3,7 @@ const {createVariableRule} = require('./lib/variable-rules')
 module.exports = createVariableRule('primer/typography', {
   'font-size': {
     expects: 'a font-size variable',
-    values: ['$h{00,0,1,2,3,4,5,6}-size', '$h{00,0,1,2,3,4,5,6}-size-mobile', '$font-size-*', '1', '1em', 'inherit']
+    values: ['$h{00,0,1,2,3,4,5,6}-size', '$font-size-*', '1', '1em', 'inherit']
   },
   'font-weight': {
     props: 'font-weight',


### PR DESCRIPTION
This is the next stage after #50: using data published in a forthcoming version of Primer CSS (see: https://github.com/primer/css/pull/949), this updates the validator logic to find suitable replacements for certain variables. It's kind of confusing to describe, but given the SCSS in Primer:

```scss
$gray-200: #e1e4e8 !default;
$border-gray: $gray-200 !default;
```

And the rule:

```js
module.exports = createVariableRule('primer/borders', {
  'border-color': {
    values: '$border-*'
  }
})
```

A stylelint config with `{rules: {'primer/borders': true}}` will be able to suggest replacements for, and autofix, the following CSS:

```diff
-.foo { border-color: $gray-200; }
+.foo { border-color: $border-gray; }
-.bar { border-color: #e1e4e8; }
+.bar { border-color: $border-gray; }
```

How? Because [the data](https://unpkg.com/@primer/css@0.0.0-81c7695/dist/variables.json) tells us that `$border-gray` has two equivalent values: `$gray-200` and `#e1e4e8`). So when the rule is created, we:

1. Iterate over all of the variables and map their equivalent values to the "canonical" variable, e.g. `$gray-200` → `$border-gray`
1. Iterate over each rule's `values` looking for variables (in this case, `$border-*`), find known variables that match that pattern (`$border-color`), and map each of their equivalent values back to the variable.
1. In this case, we end up with a generated replacement mapping of:
    ```js
    {'$gray-200': '$border-gray', '#e1e4e8': '$border-gray'}
    ```

There's actually very little new code here, which is great! In fact, we're almost entirely just deleting calls to `reverseAssignments()` with pasted-in SCSS snippets that were creating the same results. What (IMO) is key about this is that we can continue adding variables to Primer CSS and more tightly defining which ones are okay for each CSS property in parallel, rather than manually having to update the constraints here whenever we add or remove variables.