### PR TITLE
Variable rule fixes

### DIFF
--- a/__tests__/colors.js
+++ b/__tests__/colors.js
@@ -48,6 +48,22 @@ describe(ruleName, () => {
       })
   })
 
+  it('does not report color properties in at-rules', () => {
+    return stylelint
+      .lint({
+        code: `
+          @mixin foo() {
+            .x { background-color: #123456; }
+          }
+        `,
+        config: configWithOptions(true)
+      })
+      .then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data).toHaveWarningsLength(0)
+      })
+  })
+
   it('reports properties with wrong variable usage', () => {
     return stylelint
       .lint({

--- a/__tests__/colors.js
+++ b/__tests__/colors.js
@@ -73,6 +73,19 @@ describe(ruleName, () => {
       })
   })
 
+  it('does not report non-color values in background:', () => {
+    return stylelint
+      .lint({
+        code: `.x { background: red url(derp.png) top right; }`,
+        config: configWithOptions(true)
+      })
+      .then(data => {
+        expect(data).toHaveErrored()
+        expect(data).toHaveWarningsLength(1)
+        expect(data).toHaveWarnings([`Please use a background color variable instead of "red". (${ruleName})`])
+      })
+  })
+
   describe('autofix', () => {
     it('fixes text colors', () => {
       return stylelint

--- a/__tests__/colors.js
+++ b/__tests__/colors.js
@@ -55,8 +55,15 @@ describe(ruleName, () => {
           @mixin foo() {
             .x { background-color: #123456; }
           }
+
+          @each $color in $colors {
+            @include breakpoint(sm) {
+              .text-#{$color} { color: $color; }
+            }
+          }
         `,
-        config: configWithOptions(true)
+        config: configWithOptions(true),
+        syntax: 'scss'
       })
       .then(data => {
         expect(data).not.toHaveErrored()

--- a/__tests__/spacing.js
+++ b/__tests__/spacing.js
@@ -125,7 +125,9 @@ describe(ruleName, () => {
       .then(data => {
         expect(data).toHaveErrored()
         expect(data).toHaveWarningsLength(1)
-        expect(data).toHaveWarnings([`Please use a non-negative spacer variable instead of "-$spacer-1". (${ruleName})`])
+        expect(data).toHaveWarnings([
+          `Please use a non-negative spacer variable instead of "-$spacer-1". (${ruleName})`
+        ])
       })
   })
 })

--- a/__tests__/spacing.js
+++ b/__tests__/spacing.js
@@ -78,5 +78,54 @@ describe(ruleName, () => {
           `)
         })
     })
+
+    it('fixes negative margin values', () => {
+      return stylelint
+        .lint({
+          code: dedent`
+            .x { margin-top: -8px; }
+          `,
+          config: configWithOptions(true, {verbose: true}),
+          fix: true
+        })
+        .then(data => {
+          expect(data).not.toHaveErrored()
+          expect(data).toHaveWarningsLength(0)
+          expect(data.output).toEqual(dedent`
+            .x { margin-top: -$spacer-2; }
+          `)
+        })
+    })
+  })
+
+  it('validates negative margin values', () => {
+    return stylelint
+      .lint({
+        code: dedent`
+          .x { margin-top: -$spacer-1; }
+          .y { margin: -$spacer-1 -$spacer-2; }
+          .z { margin-left: -$em-spacer-4; }
+        `,
+        config: configWithOptions(true, {verbose: true})
+      })
+      .then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data).toHaveWarningsLength(0)
+      })
+  })
+
+  it('invalidates negative padding values', () => {
+    return stylelint
+      .lint({
+        code: dedent`
+          .x { padding-top: -$spacer-1; }
+        `,
+        config: configWithOptions(true, {verbose: true})
+      })
+      .then(data => {
+        expect(data).toHaveErrored()
+        expect(data).toHaveWarningsLength(1)
+        expect(data).toHaveWarnings([`Please use a non-negative spacer variable instead of "-$spacer-1". (${ruleName})`])
+      })
   })
 })

--- a/__tests__/variable-rules.js
+++ b/__tests__/variable-rules.js
@@ -1,6 +1,3 @@
-const postcss = require('postcss')
-const dedent = require('dedent')
-const stylelint = require('stylelint')
 const {createVariableRule} = require('../plugins/lib/variable-rules')
 const {requirePrimerFile} = require('../plugins/lib/primer')
 

--- a/__tests__/variable-rules.js
+++ b/__tests__/variable-rules.js
@@ -35,10 +35,9 @@ describe('variable rules (meta)', () => {
     plugin.rule(false)
     expect(createRule).not.toHaveBeenCalled()
 
-    // enabled = true should
+    // enabled = true should call it
     const options = {hi: true}
     plugin.rule(true, options)
-
     expect(createRule).toHaveBeenCalledWith(
       expect.objectContaining({
         options,

--- a/__tests__/variable-rules.js
+++ b/__tests__/variable-rules.js
@@ -1,0 +1,86 @@
+const postcss = require('postcss')
+const dedent = require('dedent')
+const stylelint = require('stylelint')
+const {createVariableRule} = require('../plugins/lib/variable-rules')
+const {requirePrimerFile} = require('../plugins/lib/primer')
+
+jest.mock('../plugins/lib/primer')
+
+const mockVariables = {
+  '$yellow-900': {
+    computed: '#ff0',
+    values: ['#ff0'],
+    refs: []
+  }
+}
+
+requirePrimerFile.mockImplementation(
+  name =>
+    ({
+      'dist/variables.json': mockVariables
+    }[name])
+)
+
+describe('variable rules (meta)', () => {
+  it('rules can be specified as functions', () => {
+    const createRule = jest.fn(() => ({
+      width: {
+        values: '*'
+      }
+    }))
+
+    const plugin = createVariableRule('primer/derp', createRule)
+    expect(plugin.ruleName).toBe('primer/derp')
+    expect(plugin.rules).toBe(createRule)
+    expect(createRule).not.toHaveBeenCalled()
+
+    // enabled = false should not call it
+    plugin.rule(false)
+    expect(createRule).not.toHaveBeenCalled()
+
+    // enabled = true should
+    const options = {hi: true}
+    plugin.rule(true, options)
+
+    expect(createRule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options,
+        ruleName: 'primer/derp',
+        variables: mockVariables
+      })
+    )
+  })
+
+  it('rules can be overridden with functions', () => {
+    const createRule = jest.fn(() => ({
+      width: {
+        values: '*'
+      }
+    }))
+
+    const plugin = createVariableRule('primer/derp', createRule)
+
+    expect(plugin.ruleName).toBe('primer/derp')
+    expect(plugin.rules).toBe(createRule)
+    expect(createRule).not.toHaveBeenCalled()
+
+    const getRules = jest.fn(() => ({
+      width: {
+        values: '1px'
+      }
+    }))
+
+    plugin.rule(true, {rules: getRules})
+
+    expect(getRules).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: {},
+        rules: {
+          width: expect.objectContaining({values: '1px'})
+        },
+        ruleName: 'primer/derp',
+        variables: mockVariables
+      })
+    )
+  })
+})

--- a/plugins/borders.js
+++ b/plugins/borders.js
@@ -43,6 +43,9 @@ module.exports = createVariableRule('primer/borders', {
   'border radius': {
     expects: 'a border radius variable',
     props: 'border{,-{top,bottom}-{left,right}}-radius',
-    values: ['$border-radius', '0', '50%', '100%']
+    values: ['$border-radius', '0', '50%', 'inherit'],
+    replacements: {
+      '100%': '50%'
+    }
   }
 })

--- a/plugins/box-shadow.js
+++ b/plugins/box-shadow.js
@@ -4,6 +4,7 @@ module.exports = createVariableRule('primer/box-shadow', {
   'box shadow': {
     expects: 'a box-shadow variable',
     props: 'box-shadow',
-    values: ['$box-shadow*', 'none']
+    values: ['$box-shadow*', '$*-shadow', 'none'],
+    singular: true
   }
 })

--- a/plugins/colors.js
+++ b/plugins/colors.js
@@ -9,7 +9,7 @@ module.exports = createVariableRule('primer/colors', {
   'text color': {
     expects: 'a text color variable',
     props: 'color',
-    values: ['$text-*'],
+    values: ['$text-*', 'inherit'],
     replacements: {
       '#fff': '$text-white',
       white: '$text-white',

--- a/plugins/colors.js
+++ b/plugins/colors.js
@@ -1,15 +1,20 @@
 const {createVariableRule} = require('./lib/variable-rules')
 
+const bgVars = ['$bg-*', '$tooltip-background-color']
+
 module.exports = createVariableRule('primer/colors', {
-  'background color': {
+  'background-color': {
     expects: 'a background color variable',
-    props: ['background{,-color}'],
-    values: ['$bg-*', 'transparent', 'none']
+    values: bgVars.concat('none', 'transparent')
+  },
+  background: {
+    expects: 'a background color variable',
+    values: bgVars.concat('none', 'transparent', 'top', 'right', 'bottom', 'left', 'center', '*px', 'url(*)')
   },
   'text color': {
     expects: 'a text color variable',
     props: 'color',
-    values: ['$text-*', 'inherit'],
+    values: ['$text-*', '$tooltip-text-color', 'inherit'],
     replacements: {
       '#fff': '$text-white',
       white: '$text-white',

--- a/plugins/lib/decl-validator.js
+++ b/plugins/lib/decl-validator.js
@@ -35,10 +35,8 @@ module.exports = function declarationValidator(rules, options = {}) {
   const validatorsByProp = new TapMap()
   const validatorsByReplacementValue = new Map()
   for (const validator of validators) {
-    if (validator.rule.replacements instanceof Object) {
-      for (const value of Object.keys(validator.rule.replacements)) {
-        validatorsByReplacementValue.set(value, validator)
-      }
+    for (const value of Object.keys(validator.rule.replacements)) {
+      validatorsByReplacementValue.set(value, validator)
     }
   }
 
@@ -81,7 +79,7 @@ module.exports = function declarationValidator(rules, options = {}) {
           fixable: false,
           replacement: undefined
         }
-      } else if (replacements && replacements.hasOwnProperty(value)) {
+      } else if (replacements[value]) {
         let replacement = value
         do {
           replacement = replacements[replacement]
@@ -141,7 +139,7 @@ module.exports = function declarationValidator(rules, options = {}) {
     }
   }
 
-  function componentValidator({expects, components, values, replacements = {}}) {
+  function componentValidator({expects, components, values, replacements}) {
     const matchesCompoundValue = anymatch(values)
     return decl => {
       const {prop, value: compoundValue} = decl
@@ -189,7 +187,7 @@ module.exports = function declarationValidator(rules, options = {}) {
       let replacement = fixable ? valueParser.stringify(parsed) : undefined
 
       // if a compound replacement exists, suggest *that* instead
-      if (replacement && replacements && replacements.hasOwnProperty(replacement)) {
+      if (replacement && replacements[replacement]) {
         do {
           replacement = replacements[replacement]
         } while (replacements[replacement])

--- a/plugins/lib/decl-validator.js
+++ b/plugins/lib/decl-validator.js
@@ -71,7 +71,7 @@ module.exports = function declarationValidator(rules, options = {}) {
     return validatorsByProp.tap(prop, () => validators.find(v => v.matchesProp(prop)))
   }
 
-  function valueValidator({expects, values, replacements}) {
+  function valueValidator({expects, values, replacements, singular = false}) {
     const matches = anymatch(values)
     return function validate({prop, value}, nested) {
       if (matches(value)) {
@@ -93,7 +93,7 @@ module.exports = function declarationValidator(rules, options = {}) {
           replacement
         }
       } else {
-        if (nested) {
+        if (nested || singular) {
           return {
             valid: false,
             errors: [{expects, prop, value}],

--- a/plugins/lib/variable-rules.js
+++ b/plugins/lib/variable-rules.js
@@ -22,7 +22,7 @@ function createVariableRule(ruleName, rules) {
     console.warn(`Unable to get variables.json from @primer/css. Replacements will need to be specified manually.`)
   }
 
-  return stylelint.createPlugin(ruleName, (enabled, options = {}, context) => {
+  const plugin = stylelint.createPlugin(ruleName, (enabled, options = {}, context) => {
     if (enabled === false) {
       return noop
     }
@@ -65,6 +65,10 @@ function createVariableRule(ruleName, rules) {
       })
     }
   })
+
+  Object.assign(plugin, {rules})
+
+  return plugin
 }
 
 function noop() {}

--- a/plugins/lib/variable-rules.js
+++ b/plugins/lib/variable-rules.js
@@ -1,4 +1,5 @@
 const stylelint = require('stylelint')
+const {requirePrimerFile} = require('./primer')
 const declarationValidator = require('./decl-validator')
 
 const CSS_IMPORTANT = '!important'
@@ -15,7 +16,7 @@ module.exports = {
 function createVariableRule(ruleName, rules) {
   let variables = {}
   try {
-    variables = require('@primer/css/dist/variables.json')
+    variables = requirePrimerFile('dist/variables.json')
   } catch (error) {
     // eslint-disable-next-line no-console
     console.warn(`Unable to get variables.json from @primer/css. Replacements will need to be specified manually.`)

--- a/plugins/lib/variable-rules.js
+++ b/plugins/lib/variable-rules.js
@@ -51,29 +51,31 @@ function createVariableRule(ruleName, rules) {
     const fixEnabled = context && context.fix && !disableFix
 
     return (root, result) => {
-      root.walkDecls(decl => {
-        const validated = validate(decl)
-        const {valid, fixable, replacement, errors} = validated
-        if (valid) {
-          // eslint-disable-next-line no-console
-          if (verbose) console.warn(`  valid!`)
-          return
-        } else if (fixEnabled && fixable) {
-          // eslint-disable-next-line no-console
-          if (verbose) console.warn(`  fixed: ${replacement}`)
-          decl.value = replacement
-        } else {
-          // eslint-disable-next-line no-console
-          if (verbose) console.warn(`  ${errors.length} error(s)`)
-          for (const error of errors) {
-            stylelint.utils.report({
-              message: messages.rejected(error),
-              node: decl,
-              result,
-              ruleName
-            })
+      root.walkRules(rule => {
+        rule.walkDecls(decl => {
+          const validated = validate(decl)
+          const {valid, fixable, replacement, errors} = validated
+          if (valid) {
+            // eslint-disable-next-line no-console
+            if (verbose) console.warn(`  valid!`)
+            return
+          } else if (fixEnabled && fixable) {
+            // eslint-disable-next-line no-console
+            if (verbose) console.warn(`  fixed: ${replacement}`)
+            decl.value = replacement
+          } else {
+            // eslint-disable-next-line no-console
+            if (verbose) console.warn(`  ${errors.length} error(s)`)
+            for (const error of errors) {
+              stylelint.utils.report({
+                message: messages.rejected(error),
+                node: decl,
+                result,
+                ruleName
+              })
+            }
           }
-        }
+        })
       })
     }
   })

--- a/plugins/lib/variable-rules.js
+++ b/plugins/lib/variable-rules.js
@@ -27,7 +27,19 @@ function createVariableRule(ruleName, rules) {
       return noop
     }
 
-    const validate = declarationValidator(Object.assign(rules, options.rules), {variables})
+    let actualRules = rules
+    let overrides = options.rules
+    if (typeof rules === 'function') {
+      actualRules = rules({variables, options, ruleName})
+    }
+    if (typeof overrides === 'function') {
+      delete options.rules
+      overrides = overrides({rules: actualRules, options, ruleName, variables})
+    }
+    if (overrides) {
+      Object.assign(actualRules, overrides)
+    }
+    const validate = declarationValidator(actualRules, {variables})
 
     const messages = stylelint.utils.ruleMessages(ruleName, {
       rejected: message => `${message}.`

--- a/plugins/spacing.js
+++ b/plugins/spacing.js
@@ -1,16 +1,27 @@
+const anymatch = require('anymatch')
 const {createVariableRule} = require('./lib/variable-rules')
 
-const SPACE_VALUES = ['$spacer-*', '-$spacer-*', '0', 'auto', 'inherit']
+const spacerVarPatterns = ['$spacer-*', '$em-spacer-*']
+const values = [...spacerVarPatterns, '0', 'auto', 'inherit']
 
-module.exports = createVariableRule('primer/spacing', {
-  margin: {
-    expects: 'a $spacer-* variable',
-    props: 'margin{,-top,-right,-bottom,-left}',
-    values: SPACE_VALUES
-  },
-  padding: {
-    expects: 'a $spacer-* variable',
-    props: 'padding{,-top,-right,-bottom,-left}',
-    values: SPACE_VALUES
+module.exports = createVariableRule('primer/spacing', ({variables}) => {
+  const spacerVars = Object.keys(variables).filter(anymatch(spacerVarPatterns))
+  const negativeValues = spacerVarPatterns.map(p => `-${p}`)
+  const replacements = {}
+  for (const name of spacerVars) {
+    replacements[`-${variables[name].computed}`] = `-${name}`
+  }
+  return {
+    margin: {
+      expects: 'a spacer variable',
+      props: 'margin{,-top,-right,-bottom,-left}',
+      values: values.concat(negativeValues),
+      replacements
+    },
+    padding: {
+      expects: 'a non-negative spacer variable',
+      props: 'padding{,-top,-right,-bottom,-left}',
+      values
+    }
   }
 })

--- a/plugins/typography.js
+++ b/plugins/typography.js
@@ -3,7 +3,7 @@ const {createVariableRule} = require('./lib/variable-rules')
 module.exports = createVariableRule('primer/typography', {
   'font-size': {
     expects: 'a font-size variable',
-    values: ['$h{00,0,1,2,3,4,5,6}-size', '$font-size-*', '1', '1em', 'inherit']
+    values: ['$h{000,00,0,1,2,3,4,5,6}-size', '$font-size-*', '1', '1em', 'inherit']
   },
   'font-weight': {
     props: 'font-weight',

--- a/plugins/typography.js
+++ b/plugins/typography.js
@@ -3,7 +3,7 @@ const {createVariableRule} = require('./lib/variable-rules')
 module.exports = createVariableRule('primer/typography', {
   'font-size': {
     expects: 'a font-size variable',
-    values: ['$h{000,00,0,1,2,3,4,5,6}-size', '$font-size-*', '1', '1em', 'inherit']
+    values: ['$body-font-size', '$h{000,00,0,1,2,3,4,5,6}-size', '$font-size-*', '1', '1em', 'inherit']
   },
   'font-weight': {
     props: 'font-weight',
@@ -15,6 +15,6 @@ module.exports = createVariableRule('primer/typography', {
   },
   'line-height': {
     props: 'line-height',
-    values: ['$lh-*', '0', '1', '1em', 'inherit']
+    values: ['$body-line-height', '$lh-*', '0', '1', '1em', 'inherit']
   }
 })


### PR DESCRIPTION
This is a follow-up for #50 and #52 after doing some testing in Primer CSS. So far, here's the deal:

- [x] Use `requirePrimerFile()` when loading `dist/variables.json` so that we can access the right file when running _within_ the `@primer/css` repo.
- [x] Walk only declarations (`prop: value`) in rules (blocks with selectors, _not_ `@rules`), and skip linting for declarations nested in `@each`, `@for`, `@function`, and `@mixin` blocks, since those can define their own variables and we can't reliably assert their values.
- [x] Make it possible to define variable rules using functions that take the variables, as in:

    ```js
    module.exports = createVariableRule('primer/whatever', ({variables}) => {
      /* do something with variables here */
    })
    ```

- [x] Make it possible to provide rule _overrides_ in local stylelint configs as functions:

    ```js
    module.exports = {
      extends: 'stylelint-config-primer',
      rules: {
        'primer/colors': [true, {
          rules: ({variables, rules}) => {
            /* do something with variables and/or rules here */
            return rules
        }]
      }
    })
    ```

- [x] Add support for an optional `singular: true` flag to rule configs, which skips the parsing of individual values in the matched properties. We use this in `primer/box-shadow` to prevent multiple warnings for a single value like `box-shadow: inset 0 1px $blue` (before there would be 4 separate ones!).
- [x] Allow `$*-shadow` variable patterns in `primer/box-shadow` to match `$btn-active-shadow` and `$form-control-shadow`
- [x] Allow `color: inherit` in `primer/colors`
- [x] Allow `$em-spacer-*` in `padding` and `margin` properties
- [x] Allow (and auto-fix!) negative spacer variables in `margin` properties
- [x] Make `primer/colors` smarter re: `background` property shorthand values (allowing positions and image `url(*)` values)
- [x] Remove `100%` from allowed values for `border-radius`, and suggest `50%` instead
- [x] Prohibit negative spacer values in `padding` properties
- [x] Allow `$h000-size` for marketing 😬 
