### PR TITLE
Prevent declarations from being validated more than once

### DIFF
--- a/__tests__/colors.js
+++ b/__tests__/colors.js
@@ -5,6 +5,7 @@ const pluginPath = require.resolve('../plugins/colors')
 const ruleName = 'primer/colors'
 const configWithOptions = (...args) => ({
   plugins: [pluginPath],
+  syntax: 'scss',
   rules: {
     [ruleName]: args
   }
@@ -171,6 +172,25 @@ describe(ruleName, () => {
     return stylelint
       .lint({
         code: `.x { color: #f00; }`,
+        config: configWithOptions(true, {verbose: true})
+      })
+      .then(data => {
+        expect(data).toHaveErrored()
+        expect(data).toHaveWarningsLength(1)
+        expect(data).toHaveWarnings([`Please use a text color variable instead of "#f00". (${ruleName})`])
+      })
+  })
+
+  it('only validates nested declarations once', () => {
+    return stylelint
+      .lint({
+        code: `
+          .x {
+            .y {
+              .z { color: #f00; }
+            }
+          }
+        `,
         config: configWithOptions(true, {verbose: true})
       })
       .then(data => {

--- a/plugins/lib/decl-validator.js
+++ b/plugins/lib/decl-validator.js
@@ -44,6 +44,7 @@ module.exports = function declarationValidator(rules, options = {}) {
   return decl => {
     if (closest(decl, isSkippableAtRule)) {
       if (verbose) {
+        // eslint-disable-next-line no-console
         console.warn(`skipping declaration: ${decl.parent.toString()}`)
       }
       // As a general rule, any rule nested in an at-rule is ignored, since

--- a/plugins/lib/decl-validator.js
+++ b/plugins/lib/decl-validator.js
@@ -6,7 +6,7 @@ const SKIP_VALUE_NODE_TYPES = new Set(['space', 'div'])
 const SKIP_AT_RULE_NAMES = new Set(['each', 'for', 'function', 'mixin'])
 
 module.exports = function declarationValidator(rules, options = {}) {
-  const {formatMessage = defaultMessageFormatter, variables} = options
+  const {formatMessage = defaultMessageFormatter, variables, verbose = false} = options
   const variableReplacements = new TapMap()
   if (variables) {
     for (const [name, {values}] of Object.entries(variables)) {
@@ -43,6 +43,9 @@ module.exports = function declarationValidator(rules, options = {}) {
 
   return decl => {
     if (closest(decl, isSkippableAtRule)) {
+      if (verbose) {
+        console.warn(`skipping declaration: ${decl.parent.toString()}`)
+      }
       // As a general rule, any rule nested in an at-rule is ignored, since
       // @for, @each, @mixin, and @function blocks can use whatever variables
       // they want

--- a/plugins/lib/variable-rules.js
+++ b/plugins/lib/variable-rules.js
@@ -49,10 +49,14 @@ function createVariableRule(ruleName, rules) {
     // overrides the "global" context.fix (--fix) linting option.
     const {verbose = false, disableFix} = options
     const fixEnabled = context && context.fix && !disableFix
+    const seen = new WeakMap()
 
     return (root, result) => {
       root.walkRules(rule => {
         rule.walkDecls(decl => {
+          if (seen.has(decl)) return
+          seen.set(decl, true)
+
           const validated = validate(decl)
           const {valid, fixable, replacement, errors} = validated
           if (valid) {

--- a/plugins/lib/variable-rules.js
+++ b/plugins/lib/variable-rules.js
@@ -31,6 +31,8 @@ function createVariableRule(ruleName, rules) {
     let overrides = options.rules
     if (typeof rules === 'function') {
       actualRules = rules({variables, options, ruleName})
+    } else {
+      actualRules = Object.assign({}, rules)
     }
     if (typeof overrides === 'function') {
       delete options.rules
@@ -54,14 +56,17 @@ function createVariableRule(ruleName, rules) {
     return (root, result) => {
       root.walkRules(rule => {
         rule.walkDecls(decl => {
-          if (seen.has(decl)) return
-          seen.set(decl, true)
+          if (seen.has(decl)) {
+            return
+          } else {
+            seen.set(decl, true)
+          }
 
           const validated = validate(decl)
           const {valid, fixable, replacement, errors} = validated
           if (valid) {
             // eslint-disable-next-line no-console
-            if (verbose) console.warn(`  valid!`)
+            if (verbose) console.warn(`valid: "${decl.toString()}" in: "${rule.selector}"`)
             return
           } else if (fixEnabled && fixable) {
             // eslint-disable-next-line no-console


### PR DESCRIPTION
While testing in github/github I noticed that some errors were being reported more than once (sometimes as many as four times!). I traced this back to 48a08b5932b726b44f3be7d3eb700c5f05125eaa, where I changed how the AST was walked to explicitly walk the rules (only) then declarations within those. Turns out, for nested selectors this was causing the nodes to be walked (and then validated) multiple times.

The solution is a [WeakMap](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap) that gets an entry for every declaration that's validated, and we skip declarations that are already in it.

While testing the fix for this I also discovered that I'd been mutating the plugin's "base" rules with overrides, so [this particular bit](https://github.com/primer/stylelint-config-primer/blob/89e89ed2182a0dd8b0f38321c4f6586cdc5c994d/__tests__/colors.js#L207-L211) was causing tests defined after it to break in unexpected ways: expected invalid values were treated as valid because the base config's `text color` rule had been overridden with the value `false`. This wouldn't normally be an issue in projects that share a single/global config, but if we were to have local overrides of certain rules it might have caused problems.