### PR TITLE
Update stylelint config to support CSS variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.1.0
+
+### :rocket: Enhancements
+
+- The `primer/colors`, `primer/borders`, and `primer/shadows` rules now allow CSS color variables with the correct functional names (e.g. `var(--color-text-primary)`). #62
+
 # 9.0.0
 
 ### :boom: Breaking Change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### :rocket: Enhancements
 
-- The `primer/colors`, `primer/borders`, and `primer/shadows` rules now allow CSS color variables with the correct functional names (e.g. `var(--color-text-primary)`). #62
+- The `primer/colors`, `primer/borders`, and `primer/box-shadow` rules now allow CSS color variables with the correct functional names (e.g. `var(--color-text-primary)`). #62
 
 # 9.0.0
 

--- a/__tests__/borders.js
+++ b/__tests__/borders.js
@@ -78,6 +78,42 @@ describe(ruleName, () => {
       })
   })
 
+  it('does not report properties with valid border color variable (prefix) ', () => {
+    return stylelint
+      .lint({
+        code: `.x { border-color: var(--color-border-primary); }`,
+        config: configWithOptions(true)
+      })
+      .then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data).toHaveWarningsLength(0)
+      })
+  })
+
+  it('does not report properties with valid border color variable (infix)', () => {
+    return stylelint
+      .lint({
+        code: `.x { border-color: var(--color-btn-border-hover); }`,
+        config: configWithOptions(true)
+      })
+      .then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data).toHaveWarningsLength(0)
+      })
+  })
+
+  it('does not report properties with valid border color variable (suffix)', () => {
+    return stylelint
+      .lint({
+        code: `.x { border-color: var(--color-diff-deletion-border); }`,
+        config: configWithOptions(true)
+      })
+      .then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data).toHaveWarningsLength(0)
+      })
+  })
+
   describe('autofix', () => {
     it('fixes border variables', () => {
       return stylelint

--- a/__tests__/borders.js
+++ b/__tests__/borders.js
@@ -78,34 +78,15 @@ describe(ruleName, () => {
       })
   })
 
-  it('does not report properties with valid border color variable (prefix) ', () => {
+  it('does not report properties with valid border color', () => {
     return stylelint
       .lint({
-        code: `.x { border-color: var(--color-border-primary); }`,
-        config: configWithOptions(true)
-      })
-      .then(data => {
-        expect(data).not.toHaveErrored()
-        expect(data).toHaveWarningsLength(0)
-      })
-  })
-
-  it('does not report properties with valid border color variable (infix)', () => {
-    return stylelint
-      .lint({
-        code: `.x { border-color: var(--color-btn-border-hover); }`,
-        config: configWithOptions(true)
-      })
-      .then(data => {
-        expect(data).not.toHaveErrored()
-        expect(data).toHaveWarningsLength(0)
-      })
-  })
-
-  it('does not report properties with valid border color variable (suffix)', () => {
-    return stylelint
-      .lint({
-        code: `.x { border-color: var(--color-diff-deletion-border); }`,
+        code: dedent`
+          .x { border-color: var(--color-border-primary); }
+          .y { border-color: var(--color-btn-border-hover); }
+          .z { border-color: var(--color-diff-deletion-border); }
+          .a { border-color: var(--color-border); }
+        `,
         config: configWithOptions(true)
       })
       .then(data => {

--- a/__tests__/box-shadow.js
+++ b/__tests__/box-shadow.js
@@ -26,34 +26,15 @@ describe(ruleName, () => {
       })
   })
 
-  it('does not report properties with valid shadow variable (prefix) ', () => {
+  it('does not report properties with valid shadow', () => {
     return stylelint
       .lint({
-        code: `.x { box-shadow: var(--color-shadow-canvas); }`,
-        config: configWithOptions(true)
-      })
-      .then(data => {
-        expect(data).not.toHaveErrored()
-        expect(data).toHaveWarningsLength(0)
-      })
-  })
-
-  it('does not report properties with valid shadow variable (infix)', () => {
-    return stylelint
-      .lint({
-        code: `.x { box-shadow: var(--color-btn-shadow-hover); }`,
-        config: configWithOptions(true)
-      })
-      .then(data => {
-        expect(data).not.toHaveErrored()
-        expect(data).toHaveWarningsLength(0)
-      })
-  })
-
-  it('does not report properties with valid shadow variable (suffix)', () => {
-    return stylelint
-      .lint({
-        code: `.x { box-shadow: var(--color-diff-deletion-shadow); }`,
+        code: dedent`
+          .x { box-shadow: var(--color-shadow-primary); }
+          .y { box-shadow: var(--color-btn-shadow-hover); }
+          .z { box-shadow: var(--color-diff-deletion-shadow); }
+          .a { box-shadow: var(--color-shadow); }
+        `,
         config: configWithOptions(true)
       })
       .then(data => {

--- a/__tests__/box-shadow.js
+++ b/__tests__/box-shadow.js
@@ -26,6 +26,42 @@ describe(ruleName, () => {
       })
   })
 
+  it('does not report properties with valid shadow variable (prefix) ', () => {
+    return stylelint
+      .lint({
+        code: `.x { box-shadow: var(--color-shadow-canvas); }`,
+        config: configWithOptions(true)
+      })
+      .then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data).toHaveWarningsLength(0)
+      })
+  })
+
+  it('does not report properties with valid shadow variable (infix)', () => {
+    return stylelint
+      .lint({
+        code: `.x { box-shadow: var(--color-btn-shadow-hover); }`,
+        config: configWithOptions(true)
+      })
+      .then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data).toHaveWarningsLength(0)
+      })
+  })
+
+  it('does not report properties with valid shadow variable (suffix)', () => {
+    return stylelint
+      .lint({
+        code: `.x { box-shadow: var(--color-diff-deletion-shadow); }`,
+        config: configWithOptions(true)
+      })
+      .then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data).toHaveWarningsLength(0)
+      })
+  })
+
   describe('autofix', () => {
     it('fixes box shadow variables', () => {
       return stylelint

--- a/__tests__/colors.js
+++ b/__tests__/colors.js
@@ -85,22 +85,10 @@ describe(ruleName, () => {
       })
   })
 
-  // it('does not report properties with valid variables', () => {
-  //   return stylelint
-  //     .lint({
-  //       code: `.x { background-color: $bg-red; }`,
-  //       config: configWithOptions(true)
-  //     })
-  //     .then(data => {
-  //       expect(data).not.toHaveErrored()
-  //       expect(data).toHaveWarningsLength(0)
-  //     })
-  // })
-
-  it('does not report properties with valid background color variable (prefix) ', () => {
+  it('does not report properties with valid variables', () => {
     return stylelint
       .lint({
-        code: `.x { background: var(--color-bg-canvas); }`,
+        code: `.x { background-color: $bg-red; }`,
         config: configWithOptions(true)
       })
       .then(data => {
@@ -109,10 +97,15 @@ describe(ruleName, () => {
       })
   })
 
-  it('does not report properties with valid background color variable (infix)', () => {
+  it('does not report properties with valid background color', () => {
     return stylelint
       .lint({
-        code: `.x { background: var(--color-btn-bg-hover); }`,
+        code: dedent`
+        .x { background-color: var(--color-bg-primary); }
+        .y { background-color: var(--color-btn-bg-hover); }
+        .z { background-color: var(--color-diff-deletion-bg); }
+        .a { background-color: var(--color-bg); }
+      `,
         config: configWithOptions(true)
       })
       .then(data => {
@@ -121,46 +114,15 @@ describe(ruleName, () => {
       })
   })
 
-  it('does not report properties with valid background color variable (suffix', () => {
+  it('does not report properties with valid text color', () => {
     return stylelint
       .lint({
-        code: `.x { background: var(--color-diff-deletion-bg); }`,
-        config: configWithOptions(true)
-      })
-      .then(data => {
-        expect(data).not.toHaveErrored()
-        expect(data).toHaveWarningsLength(0)
-      })
-  })
-
-  it('does not report properties with valid text color variable (prefix) ', () => {
-    return stylelint
-      .lint({
-        code: `.x { color: var(--color-text-primary); }`,
-        config: configWithOptions(true)
-      })
-      .then(data => {
-        expect(data).not.toHaveErrored()
-        expect(data).toHaveWarningsLength(0)
-      })
-  })
-
-  it('does not report properties with valid text color variable (infix)', () => {
-    return stylelint
-      .lint({
-        code: `.x { color: var(--color-btn-text-hover); }`,
-        config: configWithOptions(true)
-      })
-      .then(data => {
-        expect(data).not.toHaveErrored()
-        expect(data).toHaveWarningsLength(0)
-      })
-  })
-
-  it('does not report properties with valid text color variable (suffix)', () => {
-    return stylelint
-      .lint({
-        code: `.x { color: var(--color-diff-deletion-text); }`,
+        code: dedent`
+          .x { color: var(--color-text-primary); }
+          .y { color: var(--color-btn-text-hover); }
+          .z { color: var(--color-diff-deletion-text); }
+          .a { color: var(--color-text); }
+        `,
         config: configWithOptions(true)
       })
       .then(data => {

--- a/__tests__/colors.js
+++ b/__tests__/colors.js
@@ -136,7 +136,7 @@ describe(ruleName, () => {
   it('does not report properties with valid text color variable (prefix) ', () => {
     return stylelint
       .lint({
-        code: `.x { background: var(--color-text-primary); }`,
+        code: `.x { color: var(--color-text-primary); }`,
         config: configWithOptions(true)
       })
       .then(data => {
@@ -148,7 +148,7 @@ describe(ruleName, () => {
   it('does not report properties with valid text color variable (infix)', () => {
     return stylelint
       .lint({
-        code: `.x { background: var(--color-btn-text-hover); }`,
+        code: `.x { color: var(--color-btn-text-hover); }`,
         config: configWithOptions(true)
       })
       .then(data => {
@@ -157,10 +157,10 @@ describe(ruleName, () => {
       })
   })
 
-  it('does not report properties with valid text color variable (suffix', () => {
+  it('does not report properties with valid text color variable (suffix)', () => {
     return stylelint
       .lint({
-        code: `.x { background: var(--color-diff-deletion-text); }`,
+        code: `.x { color: var(--color-diff-deletion-text); }`,
         config: configWithOptions(true)
       })
       .then(data => {

--- a/__tests__/colors.js
+++ b/__tests__/colors.js
@@ -85,10 +85,34 @@ describe(ruleName, () => {
       })
   })
 
-  it('does not report properties with valid variables', () => {
+  // it('does not report properties with valid variables', () => {
+  //   return stylelint
+  //     .lint({
+  //       code: `.x { background-color: $bg-red; }`,
+  //       config: configWithOptions(true)
+  //     })
+  //     .then(data => {
+  //       expect(data).not.toHaveErrored()
+  //       expect(data).toHaveWarningsLength(0)
+  //     })
+  // })
+
+  it('does not report properties with valid background variable', () => {
     return stylelint
       .lint({
-        code: `.x { background-color: $bg-red; }`,
+        code: `.x { background: var(--color-bg-canvas); }`,
+        config: configWithOptions(true)
+      })
+      .then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data).toHaveWarningsLength(0)
+      })
+  })
+
+  it('does not report properties with valid button background variable', () => {
+    return stylelint
+      .lint({
+        code: `.x { background: var(--color-btn-bg-hover); }`,
         config: configWithOptions(true)
       })
       .then(data => {

--- a/__tests__/colors.js
+++ b/__tests__/colors.js
@@ -97,7 +97,7 @@ describe(ruleName, () => {
   //     })
   // })
 
-  it('does not report properties with valid background variable', () => {
+  it('does not report properties with valid background color variable (prefix) ', () => {
     return stylelint
       .lint({
         code: `.x { background: var(--color-bg-canvas); }`,
@@ -109,10 +109,58 @@ describe(ruleName, () => {
       })
   })
 
-  it('does not report properties with valid button background variable', () => {
+  it('does not report properties with valid background color variable (infix)', () => {
     return stylelint
       .lint({
         code: `.x { background: var(--color-btn-bg-hover); }`,
+        config: configWithOptions(true)
+      })
+      .then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data).toHaveWarningsLength(0)
+      })
+  })
+
+  it('does not report properties with valid background color variable (suffix', () => {
+    return stylelint
+      .lint({
+        code: `.x { background: var(--color-diff-deletion-bg); }`,
+        config: configWithOptions(true)
+      })
+      .then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data).toHaveWarningsLength(0)
+      })
+  })
+
+  it('does not report properties with valid text color variable (prefix) ', () => {
+    return stylelint
+      .lint({
+        code: `.x { background: var(--color-text-primary); }`,
+        config: configWithOptions(true)
+      })
+      .then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data).toHaveWarningsLength(0)
+      })
+  })
+
+  it('does not report properties with valid text color variable (infix)', () => {
+    return stylelint
+      .lint({
+        code: `.x { background: var(--color-btn-text-hover); }`,
+        config: configWithOptions(true)
+      })
+      .then(data => {
+        expect(data).not.toHaveErrored()
+        expect(data).toHaveWarningsLength(0)
+      })
+  })
+
+  it('does not report properties with valid text color variable (suffix', () => {
+    return stylelint
+      .lint({
+        code: `.x { background: var(--color-diff-deletion-text); }`,
         config: configWithOptions(true)
       })
       .then(data => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-primer",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-primer",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Sharable stylelint config used by GitHub's CSS",
   "homepage": "http://primer.style/css/tools/linting",
   "author": "GitHub, Inc.",

--- a/plugins/borders.js
+++ b/plugins/borders.js
@@ -29,7 +29,7 @@ module.exports = createVariableRule('primer/borders', {
       '$border-*',
       'transparent',
       'currentColor',
-      // Match variables in any of the following formats: --color-text-*, --color-*-text-*, --color-*-text
+      // Match variables in any of the following formats: --colorr-borde-*, --color-*-border-*, --color-*-border
       /var\(--color-(.+-)*border(-.+)*\)/
     ],
     replacements: {

--- a/plugins/borders.js
+++ b/plugins/borders.js
@@ -29,7 +29,7 @@ module.exports = createVariableRule('primer/borders', {
       '$border-*',
       'transparent',
       'currentColor',
-      // Match variables in any of the following formats: --colorr-borde-*, --color-*-border-*, --color-*-border
+      // Match variables in any of the following formats: --color-border-*, --color-*-border-*, --color-*-border
       /var\(--color-(.+-)*border(-.+)*\)/
     ],
     replacements: {

--- a/plugins/borders.js
+++ b/plugins/borders.js
@@ -25,7 +25,13 @@ module.exports = createVariableRule('primer/borders', {
   'border color': {
     expects: 'a border color variable',
     props: 'border{,-top,-right,-bottom,-left}-color',
-    values: ['$border-*', 'transparent', 'currentColor'],
+    values: [
+      '$border-*',
+      'transparent',
+      'currentColor',
+      // Match variables in any of the following formats: --color-text-*, --color-*-text-*, --color-*-text
+      /var\(--color-(.+-)*border(-.+)*\)/
+    ],
     replacements: {
       '$border-gray': '$border-color'
     }

--- a/plugins/box-shadow.js
+++ b/plugins/box-shadow.js
@@ -4,7 +4,13 @@ module.exports = createVariableRule('primer/box-shadow', {
   'box shadow': {
     expects: 'a box-shadow variable',
     props: 'box-shadow',
-    values: ['$box-shadow*', '$*-shadow', 'none'],
+    values: [
+      '$box-shadow*',
+      '$*-shadow',
+      'none',
+      // Match variables in any of the following formats: --color-shadow-*, --color-*-shadow-*, --color-*-shadow
+      /var\(--color-(.+-)*shadow(-.+)*\)/
+    ],
     singular: true
   }
 })

--- a/plugins/colors.js
+++ b/plugins/colors.js
@@ -1,6 +1,11 @@
 const {createVariableRule} = require('./lib/variable-rules')
 
-const bgVars = ['$bg-*', '$tooltip-background-color', /var\(--color(-bg|-.*-bg)-.*\)/]
+const bgVars = [
+  '$bg-*',
+  '$tooltip-background-color',
+  // Match variables in any of the following formats: --color-bg-*, --color-*-bg-*, --color-*-bg
+  /var\(--color(-bg-.*|-.*-bg-.*|-.*-bg)\)/
+]
 
 module.exports = createVariableRule('primer/colors', {
   'background-color': {

--- a/plugins/colors.js
+++ b/plugins/colors.js
@@ -4,7 +4,7 @@ const bgVars = [
   '$bg-*',
   '$tooltip-background-color',
   // Match variables in any of the following formats: --color-bg-*, --color-*-bg-*, --color-*-bg
-  /var\(--color(-bg-.*|-.*-bg-.*|-.*-bg)\)/
+  /var\(--color-(.+-)*bg(-.+)*\)/
 ]
 
 module.exports = createVariableRule('primer/colors', {
@@ -24,7 +24,7 @@ module.exports = createVariableRule('primer/colors', {
       '$tooltip-text-color',
       'inherit',
       // Match variables in any of the following formats: --color-text-*, --color-*-text-*, --color-*-text
-      /var\(--color(-text-.*|-.*-text-.*|-.*-text)\)/
+      /var\(--color-(.+-)*text(-.+)*\)/
     ],
     replacements: {
       '#fff': '$text-white',

--- a/plugins/colors.js
+++ b/plugins/colors.js
@@ -1,6 +1,6 @@
 const {createVariableRule} = require('./lib/variable-rules')
 
-const bgVars = ['$bg-*', '$tooltip-background-color']
+const bgVars = ['$bg-*', '$tooltip-background-color', 'var(--color-bg-*']
 
 module.exports = createVariableRule('primer/colors', {
   'background-color': {

--- a/plugins/colors.js
+++ b/plugins/colors.js
@@ -19,7 +19,13 @@ module.exports = createVariableRule('primer/colors', {
   'text color': {
     expects: 'a text color variable',
     props: 'color',
-    values: ['$text-*', '$tooltip-text-color', 'inherit'],
+    values: [
+      '$text-*',
+      '$tooltip-text-color',
+      'inherit',
+      // Match variables in any of the following formats: --color-text-*, --color-*-text-*, --color-*-text
+      /var\(--color(-text-.*|-.*-text-.*|-.*-text)\)/
+    ],
     replacements: {
       '#fff': '$text-white',
       white: '$text-white',

--- a/plugins/colors.js
+++ b/plugins/colors.js
@@ -1,6 +1,6 @@
 const {createVariableRule} = require('./lib/variable-rules')
 
-const bgVars = ['$bg-*', '$tooltip-background-color', 'var(--color-bg-*']
+const bgVars = ['$bg-*', '$tooltip-background-color', /var\(--color(-bg|-.*-bg)-.*\)/]
 
 module.exports = createVariableRule('primer/colors', {
   'background-color': {

--- a/plugins/lib/decl-validator.js
+++ b/plugins/lib/decl-validator.js
@@ -62,9 +62,10 @@ module.exports = function declarationValidator(rules, options = {}) {
     }
   }
 
+  // TODO: handle replacements with CSS variables
   function getVariableReplacements(values) {
     const replacements = {}
-    const varValues = (Array.isArray(values) ? values : [values]).filter(v => v.includes('$'))
+    const varValues = (Array.isArray(values) ? values : [values]).filter(v => typeof v === 'string' && v.includes('$'))
     const matches = anymatch(varValues)
     for (const [value, aliases] of variableReplacements.entries()) {
       for (const alias of aliases) {

--- a/plugins/lib/decl-validator.js
+++ b/plugins/lib/decl-validator.js
@@ -62,7 +62,6 @@ module.exports = function declarationValidator(rules, options = {}) {
     }
   }
 
-  // TODO: handle replacements with CSS variables
   function getVariableReplacements(values) {
     const replacements = {}
     const varValues = (Array.isArray(values) ? values : [values]).filter(v => typeof v === 'string' && v.includes('$'))


### PR DESCRIPTION
## Problem

To enable [color modes](https://github.com/primer/css/pull/1131) in Primer CSS, we are transitioning from SCSS variables for colors to CSS variables. Our [stylelint config](https://github.com/primer/stylelint-config-primer), however, does not recognize CSS variables, resulting in linting errors.

## Solution

This PR updates the `primer/colors`, `primer/borders`, and `primer/box-shadow` rules to allow CSS color variables with the correct functional names. For example, `color: var(--color-text-primary)` will no longer cause a linting error.

**Note:** This PR only *adds* support for CSS color variables. It does not remove support for SCSS color variables. Eventually, we will want to update our stylelint config to discourage the use of SCSS color variables, but that should be done in a separate PR. 

## Impact

We will now be able to keep stylelint enabled in Primer CSS and dotcom as we transition from SCSS variables to CSS variables as part of the color modes project.

Closes https://github.com/primer/css/issues/1176