### PR TITLE
Cache variable definitions in no-undefined-vars rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.2.1
+
+### :bug: Bug fixes
+
+- Fix slow runtime by caching variable definitions in `primer/no-undefined-vars` rule
+
 # 9.2.0
 
 ### :rocket: Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### :bug: Bug fixes
 
 - Fix slow runtime by caching variable definitions in `primer/no-undefined-vars` rule
+- Fix duplicate errors in `primer/no-undefined-vars` rule
 
 # 9.2.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-primer",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-primer",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Sharable stylelint config used by GitHub's CSS",
   "homepage": "http://primer.style/css/tools/linting",
   "author": "GitHub, Inc.",

--- a/plugins/no-undefined-vars.js
+++ b/plugins/no-undefined-vars.js
@@ -26,9 +26,18 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
   const log = verbose ? (...args) => console.warn(...args) : noop
   const definedVariables = getDefinedVariables(files, log)
 
+  // Keep track of declarations we've already seen
+  const seen = new WeakMap()
+
   return (root, result) => {
     root.walkRules(rule => {
       rule.walkDecls(decl => {
+        if (seen.has(decl)) {
+          return
+        } else {
+          seen.set(decl, true)
+        }
+
         for (const [, variableName] of matchAll(decl.value, variableReferenceRegex)) {
           if (!definedVariables.has(variableName)) {
             stylelint.utils.report({

--- a/plugins/no-undefined-vars.js
+++ b/plugins/no-undefined-vars.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 const stylelint = require('stylelint')
 const matchAll = require('string.prototype.matchall')
 const globby = require('globby')
+const TapMap = require('tap-map')
 
 const ruleName = 'primer/no-undefined-vars'
 const messages = stylelint.utils.ruleMessages(ruleName, {
@@ -15,6 +16,9 @@ const variableDefinitionRegex = /(--[\w|-]*):/g
 // eslint-disable-next-line no-useless-escape
 const variableReferenceRegex = /var\(([^\)]*)\)/g
 
+const cwd = process.cwd()
+const cache = new TapMap()
+
 module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
   if (!enabled) {
     return noop
@@ -23,7 +27,8 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
   const {files = ['**/*.scss', '!node_modules'], verbose = false} = options
   // eslint-disable-next-line no-console
   const log = verbose ? (...args) => console.warn(...args) : noop
-  const definedVariables = getDefinedVariables(files, log)
+  const cacheOptions = {files, cwd}
+  const definedVariables = getDefinedVariables(cacheOptions, log)
 
   return (root, result) => {
     root.walkRules(rule => {
@@ -43,18 +48,20 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
   }
 })
 
-function getDefinedVariables(files, log) {
-  const definedVariables = new Set()
-
-  for (const file of globby.sync(files)) {
-    const css = fs.readFileSync(file, 'utf-8')
-    for (const [, variableName] of matchAll(css, variableDefinitionRegex)) {
-      log(`${variableName} defined in ${file}`)
-      definedVariables.add(variableName)
+function getDefinedVariables(cacheOptions, log) {
+  const cacheKey = JSON.stringify(cacheOptions)
+  return cache.tap(cacheKey, () => {
+    const definedVariables = new Set()
+    for (const file of globby.sync(cacheOptions.files)) {
+      const css = fs.readFileSync(file, 'utf-8')
+      for (const [, variableName] of matchAll(css, variableDefinitionRegex)) {
+        log(`${variableName} defined in ${file}`)
+        definedVariables.add(variableName)
+      }
     }
-  }
 
-  return definedVariables
+    return definedVariables
+  })
 }
 
 function noop() {}


### PR DESCRIPTION
## Problem

`primer/no-undefined-vars` was taking a _very_ long time to run in Primer CSS because it was searching for variable definitions in all files every time it linted a file (`O(n^2)` 😱).

## Solution

This PR caches the defined variable names so we only search for them once.