### PR TITLE
Allow CSS variables with fallback values in no-undefined-vars

### DIFF
--- a/__tests__/no-undefined-vars.js
+++ b/__tests__/no-undefined-vars.js
@@ -16,6 +16,7 @@ testRule({
 
   accept: [
     {code: '.x { color: var(--color-text-primary); }'},
+    {code: '.x { color: var(--color-text-primary, #000000); }'},
     {code: '.x { background-color: var(--color-counter-bg); }'},
     {code: '.x { margin: var(--spacing-spacer-1); }'}
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-primer",
-  "version": "9.2.2",
+  "version": "9.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-primer",
-  "version": "9.2.2",
+  "version": "9.2.3",
   "description": "Sharable stylelint config used by GitHub's CSS",
   "homepage": "http://primer.style/css/tools/linting",
   "author": "GitHub, Inc.",

--- a/plugins/no-undefined-vars.js
+++ b/plugins/no-undefined-vars.js
@@ -14,7 +14,7 @@ const variableDefinitionRegex = /(--[\w|-]*):/g
 
 // Match CSS variable references (e.g var(--color-text-primary))
 // eslint-disable-next-line no-useless-escape
-const variableReferenceRegex = /var\(([^\)]*)\)/g
+const variableReferenceRegex = /var\(([^\),]*)\)/g
 
 module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
   if (!enabled) {


### PR DESCRIPTION
This PR fixes `no-undefined-vars` failing for values with fallbacks, e.g. `var(--color-text-primary, #000000)`