### PR TITLE
Add additional logging and handle more edges cases

### DIFF
--- a/.changeset/brown-tigers-buy.md
+++ b/.changeset/brown-tigers-buy.md
@@ -1,0 +1,5 @@
+---
+'stylelint-config-primer': patch
+---
+
+Add additinal verbose logging to `no-undefined-vars`

--- a/.changeset/fair-pets-relax.md
+++ b/.changeset/fair-pets-relax.md
@@ -1,0 +1,5 @@
+---
+'stylelint-config-primer': patch
+---
+
+Fix handling of edge-cases in no-undefined-vars

--- a/__tests__/__fixtures__/defines-new-color-vars.scss
+++ b/__tests__/__fixtures__/defines-new-color-vars.scss
@@ -1,8 +1,12 @@
 :root {
+  // @include color-mode-var('my-commented-color', var(--color-scale-blue-5), var(--color-scale-blue-3));
+  // --color-my-other-commented-color: #1b1f23;
   @include color-mode-var('my-first-feature', var(--color-scale-blue-5), var(--color-scale-blue-3));
   @include color-mode-var(
     'my-second-feature',
     var(--color-scale-green-5),
     var(--color-scale-red-3)
   );
+
+  $readme-blue--light: #4f80f9;
 }

--- a/__tests__/no-undefined-vars.js
+++ b/__tests__/no-undefined-vars.js
@@ -32,6 +32,26 @@ testRule({
       line: 1,
       column: 6
     },
+    // checks to ensure other declarations with a double-dash
+    // aren't accidentally parsed as CSS variables
+    {
+      code: '.x { color: var(--light); }',
+      message: messages.rejected('--light'),
+      line: 1,
+      column: 6
+    },
+    {
+      code: '.x { color: var(--color-my-commented-color); }',
+      message: messages.rejected('--color-my-commented-color'),
+      line: 1,
+      column: 6
+    },
+    {
+      code: '.x { color: var(--color-my-other-commented-color); }',
+      message: messages.rejected('--color-my-other-commented-color'),
+      line: 1,
+      column: 6
+    },
     {
       code: '.x { color: var(--color-bar, #000000); }',
       message: messages.rejected('--color-bar'),

--- a/plugins/no-undefined-vars.js
+++ b/plugins/no-undefined-vars.js
@@ -81,12 +81,15 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
 const cwd = process.cwd()
 const cache = new TapMap()
 
-function getDefinedVariables(files, log) {
-  const cacheKey = JSON.stringify({files, cwd})
+function getDefinedVariables(globs, log) {
+  const cacheKey = JSON.stringify({globs, cwd})
   return cache.tap(cacheKey, () => {
     const definedVariables = new Set()
 
-    for (const file of globby.sync(files)) {
+    const files = globby.sync(globs)
+    log(`Scanning ${files.length} SCSS files for CSS variables`)
+    for (const file of files) {
+      log(`==========\nLooking for CSS variable definitions in ${file}`)
       const css = fs.readFileSync(file, 'utf-8')
       for (const [, variableName] of matchAll(css, variableDefinitionRegex)) {
         log(`${variableName} defined in ${file}`)

--- a/plugins/no-undefined-vars.js
+++ b/plugins/no-undefined-vars.js
@@ -10,10 +10,10 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
 })
 
 // Match CSS variable definitions (e.g. --color-text-primary:)
-const variableDefinitionRegex = /(--[\w|-]*):/g
+const variableDefinitionRegex = /^\s*(--[\w|-]+):/gm
 
 // Match CSS variables defined with the color-mode-var mixin (e.g. @include color-mode-var(my-feature, ...))
-const colorModeVariableDefinitionRegex = /color-mode-var\s*\(\s*['"]?([^'",]+)['"]?/g
+const colorModeVariableDefinitionRegex = /^\s*@include\s+color-mode-var\s*\(\s*['"]?([^'",]+)['"]?/gm
 
 // Match CSS variable references (e.g var(--color-text-primary))
 // eslint-disable-next-line no-useless-escape
@@ -46,7 +46,7 @@ module.exports = stylelint.createPlugin(ruleName, (enabled, options = {}) => {
 
     root.walkAtRules(rule => {
       if (rule.name === 'include' && rule.params.startsWith('color-mode-var')) {
-        const innerMatch = rule.params.match(/^color-mode-var\s*\(\s*(.*)\)\s*$/)
+        const innerMatch = rule.params.match(/^color-mode-var\s*\(\s*(.*)\s*\);?\s*$/)
         if (innerMatch.length !== 2) {
           return
         }


### PR DESCRIPTION
This PR adds additional `verbose` logging to the `no-undefined-vars` rule to assist with tracking down issues when linting a large codebase. Additionally, it adds handling for the following edge cases:

* Commented out colors (`// --color-my-other-commented-color: #1b1f23;`)
* Commented out `color-mode-var` invocations (`// @include color-mode-var('my-commented-color', ...`)
* Regular declarations with two dashes (`$readme-blue--light: #4f80f9`)