### PR TITLE
Reapply lost changes for forcing a prerelease update on every commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches-ignore:
-      - master
-      - changeset-release/**
+on: [push]
 
 jobs:
   ci:
@@ -35,6 +31,8 @@ jobs:
 
       - name: Release snapshot
         run: |
+          echo "$( jq '.version = "0.0.0"' package.json )" > package.json
+          echo -e "---\n'stylelint-config-primer': patch\n---\n\nFake entry to force publishing" > .changeset/force-snapshot-release.md
           yarn changeset version --snapshot
           yarn changeset publish --tag canary
         env:


### PR DESCRIPTION
Looks like changeset-bot force-pushes against the release PR it creates, which means it overwrote my changes to `ci.yml`. Luckily Git is awesome, so here they are again.