### PR TITLE
Add option to add URL to error message

### DIFF
--- a/.changeset/soft-weeks-film.md
+++ b/.changeset/soft-weeks-film.md
@@ -1,0 +1,5 @@
+---
+'stylelint-config-primer': patch
+---
+
+Allow rules to optionally display a URL with their message.

--- a/__tests__/borders.js
+++ b/__tests__/borders.js
@@ -21,7 +21,9 @@ describe(ruleName, () => {
       })
       .then(data => {
         expect(data).toHaveErrored()
-        expect(data).toHaveWarnings([`Please use "$border-red" instead of "$red". (${ruleName})`])
+        expect(data).toHaveWarnings([
+          `Please use "$border-red" instead of "$red". See https://primer.style/css/utilities/borders. (${ruleName})`
+        ])
       })
   })
 
@@ -36,9 +38,9 @@ describe(ruleName, () => {
       .then(data => {
         expect(data).toHaveErrored()
         expect(data).toHaveWarnings([
-          `Please use "$border-width" instead of "1px". (${ruleName})`,
-          `Please use "$border-style" instead of "solid". (${ruleName})`,
-          `Please use a border color variable instead of "gray". (${ruleName})`
+          `Please use "$border-width" instead of "1px". See https://primer.style/css/utilities/borders. (${ruleName})`,
+          `Please use "$border-style" instead of "solid". See https://primer.style/css/utilities/borders. (${ruleName})`,
+          `Please use a border color variable instead of "gray". See https://primer.style/css/utilities/borders. (${ruleName})`
         ])
       })
   })
@@ -54,8 +56,8 @@ describe(ruleName, () => {
       .then(data => {
         expect(data).toHaveErrored()
         expect(data).toHaveWarnings([
-          `Please use a border width variable instead of "calc($spacer-2 + var(--derp))". (${ruleName})`,
-          `Please use a border color variable instead of "rgba($border-gray-dark, 50%)". (${ruleName})`
+          `Please use a border width variable instead of "calc($spacer-2 + var(--derp))". See https://primer.style/css/utilities/borders. (${ruleName})`,
+          `Please use a border color variable instead of "rgba($border-gray-dark, 50%)". See https://primer.style/css/utilities/borders. (${ruleName})`
         ])
       })
   })

--- a/__tests__/box-shadow.js
+++ b/__tests__/box-shadow.js
@@ -21,7 +21,7 @@ describe(ruleName, () => {
         expect(data).toHaveErrored()
         expect(data).toHaveWarningsLength(1)
         expect(data).toHaveWarnings([
-          `Please use "$box-shadow" instead of "0 1px 1px rgba($black, 0.1)". (${ruleName})`
+          `Please use "$box-shadow" instead of "0 1px 1px rgba($black, 0.1)". See https://primer.style/css/utilities/box-shadow. (${ruleName})`
         ])
       })
   })

--- a/__tests__/colors.js
+++ b/__tests__/colors.js
@@ -21,7 +21,9 @@ describe(ruleName, () => {
       .then(data => {
         expect(data).toHaveErrored()
         expect(data).toHaveWarningsLength(1)
-        expect(data).toHaveWarnings([`Please use a text color variable instead of "#f00". (${ruleName})`])
+        expect(data).toHaveWarnings([
+          `Please use a text color variable instead of "#f00". See https://primer.style/css/utilities/colors. (${ruleName})`
+        ])
       })
   })
 
@@ -81,7 +83,9 @@ describe(ruleName, () => {
       .then(data => {
         expect(data).toHaveErrored()
         expect(data).toHaveWarningsLength(1)
-        expect(data).toHaveWarnings([`Please use a background color variable instead of "$red". (${ruleName})`])
+        expect(data).toHaveWarnings([
+          `Please use a background color variable instead of "$red". See https://primer.style/css/utilities/colors. (${ruleName})`
+        ])
       })
   })
 
@@ -140,7 +144,9 @@ describe(ruleName, () => {
       .then(data => {
         expect(data).toHaveErrored()
         expect(data).toHaveWarningsLength(1)
-        expect(data).toHaveWarnings([`Please use a background color variable instead of "red". (${ruleName})`])
+        expect(data).toHaveWarnings([
+          `Please use a background color variable instead of "red". See https://primer.style/css/utilities/colors. (${ruleName})`
+        ])
       })
   })
 
@@ -211,7 +217,9 @@ describe(ruleName, () => {
       .then(data => {
         expect(data).toHaveErrored()
         expect(data).toHaveWarningsLength(1)
-        expect(data).toHaveWarnings([`Please use a text color variable instead of "#f00". (${ruleName})`])
+        expect(data).toHaveWarnings([
+          `Please use a text color variable instead of "#f00". See https://primer.style/css/utilities/colors. (${ruleName})`
+        ])
       })
   })
 
@@ -230,7 +238,9 @@ describe(ruleName, () => {
       .then(data => {
         expect(data).toHaveErrored()
         expect(data).toHaveWarningsLength(1)
-        expect(data).toHaveWarnings([`Please use a text color variable instead of "#f00". (${ruleName})`])
+        expect(data).toHaveWarnings([
+          `Please use a text color variable instead of "#f00". See https://primer.style/css/utilities/colors. (${ruleName})`
+        ])
       })
   })
 

--- a/__tests__/spacing.js
+++ b/__tests__/spacing.js
@@ -20,7 +20,9 @@ describe(ruleName, () => {
       .then(data => {
         expect(data).toHaveErrored()
         expect(data).toHaveWarningsLength(1)
-        expect(data).toHaveWarnings([`Please use "$spacer-1" instead of "4px". (${ruleName})`])
+        expect(data).toHaveWarnings([
+          `Please use "$spacer-1" instead of "4px". See https://primer.style/css/support/spacing. (${ruleName})`
+        ])
       })
   })
 
@@ -126,7 +128,7 @@ describe(ruleName, () => {
         expect(data).toHaveErrored()
         expect(data).toHaveWarningsLength(1)
         expect(data).toHaveWarnings([
-          `Please use a non-negative spacer variable instead of "-$spacer-1". (${ruleName})`
+          `Please use a non-negative spacer variable instead of "-$spacer-1". See https://primer.style/css/support/spacing. (${ruleName})`
         ])
       })
   })

--- a/__tests__/typography.js
+++ b/__tests__/typography.js
@@ -24,8 +24,8 @@ describe(ruleName, () => {
         .then(data => {
           expect(data).toHaveErrored()
           expect(data).toHaveWarnings([
-            `Please use a font-size variable instead of "11px". (${ruleName})`,
-            `Please use a font-size variable instead of "$spacer-3". (${ruleName})`
+            `Please use a font-size variable instead of "11px". See https://primer.style/css/utilities/typography. (${ruleName})`,
+            `Please use a font-size variable instead of "$spacer-3". See https://primer.style/css/utilities/typography. (${ruleName})`
           ])
         })
     })

--- a/plugins/borders.js
+++ b/plugins/borders.js
@@ -1,57 +1,61 @@
 const {createVariableRule} = require('./lib/variable-rules')
 
-module.exports = createVariableRule('primer/borders', {
-  border: {
-    expects: 'a border variable',
-    props: 'border{,-top,-right,-bottom,-left}',
-    values: ['$border', 'none', '0'],
-    components: ['border-width', 'border-style', 'border-color'],
-    replacements: {
-      // because shorthand border properties ¯\_(ツ)_/¯
-      '$border-width $border-style $border-gray': '$border',
-      '$border-width $border-gray $border-style': '$border',
-      '$border-style $border-width $border-gray': '$border',
-      '$border-style $border-gray $border-width': '$border',
-      '$border-gray $border-width $border-style': '$border',
-      '$border-gray $border-style $border-width': '$border',
-      '$border-width $border-style $border-color': '$border',
-      '$border-width $border-color $border-style': '$border',
-      '$border-style $border-width $border-color': '$border',
-      '$border-style $border-color $border-width': '$border',
-      '$border-color $border-width $border-style': '$border',
-      '$border-color $border-style $border-width': '$border'
+module.exports = createVariableRule(
+  'primer/borders',
+  {
+    border: {
+      expects: 'a border variable',
+      props: 'border{,-top,-right,-bottom,-left}',
+      values: ['$border', 'none', '0'],
+      components: ['border-width', 'border-style', 'border-color'],
+      replacements: {
+        // because shorthand border properties ¯\_(ツ)_/¯
+        '$border-width $border-style $border-gray': '$border',
+        '$border-width $border-gray $border-style': '$border',
+        '$border-style $border-width $border-gray': '$border',
+        '$border-style $border-gray $border-width': '$border',
+        '$border-gray $border-width $border-style': '$border',
+        '$border-gray $border-style $border-width': '$border',
+        '$border-width $border-style $border-color': '$border',
+        '$border-width $border-color $border-style': '$border',
+        '$border-style $border-width $border-color': '$border',
+        '$border-style $border-color $border-width': '$border',
+        '$border-color $border-width $border-style': '$border',
+        '$border-color $border-style $border-width': '$border'
+      }
+    },
+    'border color': {
+      expects: 'a border color variable',
+      props: 'border{,-top,-right,-bottom,-left}-color',
+      values: [
+        '$border-*',
+        'transparent',
+        'currentColor',
+        // Match variables in any of the following formats: --color-border-*, --color-*-border-*, --color-*-border
+        /var\(--color-(.+-)*border(-.+)*\)/
+      ],
+      replacements: {
+        '$border-gray': '$border-color'
+      }
+    },
+    'border style': {
+      expects: 'a border style variable',
+      props: 'border{,-top,-right,-bottom,-left}-style',
+      values: ['$border-style', 'none']
+    },
+    'border width': {
+      expects: 'a border width variable',
+      props: 'border{,-top,-right,-bottom,-left}-width',
+      values: ['$border-width*', '0']
+    },
+    'border radius': {
+      expects: 'a border radius variable',
+      props: 'border{,-{top,bottom}-{left,right}}-radius',
+      values: ['$border-radius', '0', '50%', 'inherit'],
+      replacements: {
+        '100%': '50%'
+      }
     }
   },
-  'border color': {
-    expects: 'a border color variable',
-    props: 'border{,-top,-right,-bottom,-left}-color',
-    values: [
-      '$border-*',
-      'transparent',
-      'currentColor',
-      // Match variables in any of the following formats: --color-border-*, --color-*-border-*, --color-*-border
-      /var\(--color-(.+-)*border(-.+)*\)/
-    ],
-    replacements: {
-      '$border-gray': '$border-color'
-    }
-  },
-  'border style': {
-    expects: 'a border style variable',
-    props: 'border{,-top,-right,-bottom,-left}-style',
-    values: ['$border-style', 'none']
-  },
-  'border width': {
-    expects: 'a border width variable',
-    props: 'border{,-top,-right,-bottom,-left}-width',
-    values: ['$border-width*', '0']
-  },
-  'border radius': {
-    expects: 'a border radius variable',
-    props: 'border{,-{top,bottom}-{left,right}}-radius',
-    values: ['$border-radius', '0', '50%', 'inherit'],
-    replacements: {
-      '100%': '50%'
-    }
-  }
-})
+  'https://primer.style/css/utilities/borders'
+)

--- a/plugins/box-shadow.js
+++ b/plugins/box-shadow.js
@@ -1,16 +1,20 @@
 const {createVariableRule} = require('./lib/variable-rules')
 
-module.exports = createVariableRule('primer/box-shadow', {
-  'box shadow': {
-    expects: 'a box-shadow variable',
-    props: 'box-shadow',
-    values: [
-      '$box-shadow*',
-      '$*-shadow',
-      'none',
-      // Match variables in any of the following formats: --color-shadow-*, --color-*-shadow-*, --color-*-shadow
-      /var\(--color-(.+-)*shadow(-.+)*\)/
-    ],
-    singular: true
-  }
-})
+module.exports = createVariableRule(
+  'primer/box-shadow',
+  {
+    'box shadow': {
+      expects: 'a box-shadow variable',
+      props: 'box-shadow',
+      values: [
+        '$box-shadow*',
+        '$*-shadow',
+        'none',
+        // Match variables in any of the following formats: --color-shadow-*, --color-*-shadow-*, --color-*-shadow
+        /var\(--color-(.+-)*shadow(-.+)*\)/
+      ],
+      singular: true
+    }
+  },
+  'https://primer.style/css/utilities/box-shadow'
+)

--- a/plugins/colors.js
+++ b/plugins/colors.js
@@ -7,30 +7,34 @@ const bgVars = [
   /var\(--color-(.+-)*bg(-.+)*\)/
 ]
 
-module.exports = createVariableRule('primer/colors', {
-  'background-color': {
-    expects: 'a background color variable',
-    values: bgVars.concat('none', 'transparent')
-  },
-  background: {
-    expects: 'a background color variable',
-    values: bgVars.concat('none', 'transparent', 'top', 'right', 'bottom', 'left', 'center', '*px', 'url(*)')
-  },
-  'text color': {
-    expects: 'a text color variable',
-    props: 'color',
-    values: [
-      '$text-*',
-      '$tooltip-text-color',
-      'inherit',
-      // Match variables in any of the following formats: --color-text-*, --color-*-text-*, --color-*-text
-      /var\(--color-(.+-)*text(-.+)*\)/
-    ],
-    replacements: {
-      '#fff': '$text-white',
-      white: '$text-white',
-      '#000': '$text-gray-dark',
-      black: '$black'
+module.exports = createVariableRule(
+  'primer/colors',
+  {
+    'background-color': {
+      expects: 'a background color variable',
+      values: bgVars.concat('none', 'transparent')
+    },
+    background: {
+      expects: 'a background color variable',
+      values: bgVars.concat('none', 'transparent', 'top', 'right', 'bottom', 'left', 'center', '*px', 'url(*)')
+    },
+    'text color': {
+      expects: 'a text color variable',
+      props: 'color',
+      values: [
+        '$text-*',
+        '$tooltip-text-color',
+        'inherit',
+        // Match variables in any of the following formats: --color-text-*, --color-*-text-*, --color-*-text
+        /var\(--color-(.+-)*text(-.+)*\)/
+      ],
+      replacements: {
+        '#fff': '$text-white',
+        white: '$text-white',
+        '#000': '$text-gray-dark',
+        black: '$black'
+      }
     }
-  }
-})
+  },
+  'https://primer.style/css/utilities/colors'
+)

--- a/plugins/lib/variable-rules.js
+++ b/plugins/lib/variable-rules.js
@@ -13,7 +13,7 @@ module.exports = {
   CSS_IMPORTANT
 }
 
-function createVariableRule(ruleName, rules) {
+function createVariableRule(ruleName, rules, url) {
   let variables = {}
   try {
     variables = requirePrimerFile('dist/variables.json')
@@ -42,10 +42,6 @@ function createVariableRule(ruleName, rules) {
       Object.assign(actualRules, overrides)
     }
     const validate = declarationValidator(actualRules, {variables})
-
-    const messages = stylelint.utils.ruleMessages(ruleName, {
-      rejected: message => `${message}.`
-    })
 
     // The stylelint docs suggest respecting a "disableFix" rule option that
     // overrides the "global" context.fix (--fix) linting option.
@@ -76,8 +72,19 @@ function createVariableRule(ruleName, rules) {
             // eslint-disable-next-line no-console
             if (verbose) console.warn(`  ${errors.length} error(s)`)
             for (const error of errors) {
+              const message = stylelint.utils
+                .ruleMessages(ruleName, {
+                  rejected: message => {
+                    if (url) {
+                      return `${message}. See ${url}.`
+                    }
+                    return `${message}.`
+                  }
+                })
+                .rejected(error)
+
               stylelint.utils.report({
-                message: messages.rejected(error),
+                message,
                 node: decl,
                 result,
                 ruleName

--- a/plugins/spacing.js
+++ b/plugins/spacing.js
@@ -4,24 +4,28 @@ const {createVariableRule} = require('./lib/variable-rules')
 const spacerVarPatterns = ['$spacer-*', '$em-spacer-*']
 const values = [...spacerVarPatterns, '0', 'auto', 'inherit']
 
-module.exports = createVariableRule('primer/spacing', ({variables}) => {
-  const spacerVars = Object.keys(variables).filter(anymatch(spacerVarPatterns))
-  const negativeValues = spacerVarPatterns.map(p => `-${p}`)
-  const replacements = {}
-  for (const name of spacerVars) {
-    replacements[`-${variables[name].computed}`] = `-${name}`
-  }
-  return {
-    margin: {
-      expects: 'a spacer variable',
-      props: 'margin{,-top,-right,-bottom,-left}',
-      values: values.concat(negativeValues),
-      replacements
-    },
-    padding: {
-      expects: 'a non-negative spacer variable',
-      props: 'padding{,-top,-right,-bottom,-left}',
-      values
+module.exports = createVariableRule(
+  'primer/spacing',
+  ({variables}) => {
+    const spacerVars = Object.keys(variables).filter(anymatch(spacerVarPatterns))
+    const negativeValues = spacerVarPatterns.map(p => `-${p}`)
+    const replacements = {}
+    for (const name of spacerVars) {
+      replacements[`-${variables[name].computed}`] = `-${name}`
     }
-  }
-})
+    return {
+      margin: {
+        expects: 'a spacer variable',
+        props: 'margin{,-top,-right,-bottom,-left}',
+        values: values.concat(negativeValues),
+        replacements
+      },
+      padding: {
+        expects: 'a non-negative spacer variable',
+        props: 'padding{,-top,-right,-bottom,-left}',
+        values
+      }
+    }
+  },
+  'https://primer.style/css/support/spacing'
+)

--- a/plugins/typography.js
+++ b/plugins/typography.js
@@ -1,20 +1,24 @@
 const {createVariableRule} = require('./lib/variable-rules')
 
-module.exports = createVariableRule('primer/typography', {
-  'font-size': {
-    expects: 'a font-size variable',
-    values: ['$body-font-size', '$h{000,00,0,1,2,3,4,5,6}-size', '$font-size-*', '1', '1em', 'inherit']
-  },
-  'font-weight': {
-    props: 'font-weight',
-    values: ['$font-weight-*', 'inherit'],
-    replacements: {
-      bold: '$font-weight-bold',
-      normal: '$font-weight-normal'
+module.exports = createVariableRule(
+  'primer/typography',
+  {
+    'font-size': {
+      expects: 'a font-size variable',
+      values: ['$body-font-size', '$h{000,00,0,1,2,3,4,5,6}-size', '$font-size-*', '1', '1em', 'inherit']
+    },
+    'font-weight': {
+      props: 'font-weight',
+      values: ['$font-weight-*', 'inherit'],
+      replacements: {
+        bold: '$font-weight-bold',
+        normal: '$font-weight-normal'
+      }
+    },
+    'line-height': {
+      props: 'line-height',
+      values: ['$body-line-height', '$lh-*', '0', '1', '1em', 'inherit']
     }
   },
-  'line-height': {
-    props: 'line-height',
-    values: ['$body-line-height', '$lh-*', '0', '1', '1em', 'inherit']
-  }
-})
+  'https://primer.style/css/utilities/typography'
+)


### PR DESCRIPTION
I think this could be a neat addition that will funnel users to the documentation when they hit errors and warnings.

I just implemented it on the `borders` ruleset but I can add the others before merging if this looks good to y'all.