### PR TITLE
Remove rules that clash with prettier

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,6 @@ module.exports = {
     'function-parentheses-space-inside': 'never-single-line',
     'function-url-quotes': 'always',
     'function-whitespace-after': 'always',
-    indentation: 2,
     'length-zero-no-unit': true,
     'max-empty-lines': 1,
     'max-nesting-depth': 3,
@@ -135,10 +134,8 @@ module.exports = {
     'selector-type-case': 'lower',
     'shorthand-property-no-redundant-values': true,
     'string-no-newline': true,
-    'string-quotes': 'double',
     'unit-case': 'lower',
     'unit-no-unknown': true,
-    'value-list-comma-newline-after': 'always-multi-line',
     'value-list-comma-space-after': 'always-single-line',
     'value-list-comma-space-before': 'never',
     'value-no-vendor-prefix': true


### PR DESCRIPTION
I want to enable [prettier](https://prettier.io/) on `github/github` but it clashes with some formatting rules in stylelint so I would like to remove those rules. I would have overwritten these in the local stylelint config but as far as I can tell, that is not possible 🤔 

I could remove all the [stylistic issues](https://stylelint.io/user-guide/rules/list#stylistic-issues) but I feel like that would be too heavy handed.