### PR TITLE
Adding reporting to the linter to know how many variables are replaced

### DIFF
--- a/.changeset/wicked-singers-rule.md
+++ b/.changeset/wicked-singers-rule.md
@@ -1,0 +1,5 @@
+---
+"stylelint-config-primer": patch
+---
+
+Adding reporting to the linter to know how many variables are replaced


### PR DESCRIPTION
The goal of this is to add reporting to the linter so we can see how many variables are replaced.

By turning `verbose: true` on in the codebases' stylelint config you can see the report printed out.

The one thing I don't know how to solve is the count keeps printing out as it's climbing. Because the plugin is run for each file, not sure how to tally them. Any ideas would be accepted. 